### PR TITLE
feat: export piniaSymbol

### DIFF
--- a/packages/pinia/src/index.ts
+++ b/packages/pinia/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @module pinia
  */
-export { setActivePinia, getActivePinia } from './rootStore'
+export { setActivePinia, getActivePinia, piniaSymbol } from './rootStore'
 export { createPinia, disposePinia } from './createPinia'
 export type { Pinia, PiniaPlugin, PiniaPluginContext } from './rootStore'
 

--- a/packages/pinia/src/rootStore.ts
+++ b/packages/pinia/src/rootStore.ts
@@ -99,6 +99,17 @@ export interface Pinia {
   _testing?: boolean
 }
 
+/**
+ * Symbol used to provide/inject the pinia instance in the app. Used internally
+ * and exposed for testing purposes and edge cases like storybook. Could break
+ * in a minor, **USE AT YOUR OWN RISK**.
+ *
+ * For context, see:
+ * - https://github.com/vuejs/pinia/issues/870
+ * - https://github.com/vuejs/pinia/pull/2973
+ *
+ * @internal
+ */
 export const piniaSymbol = (
   __DEV__ ? Symbol('pinia') : /* istanbul ignore next */ Symbol()
 ) as InjectionKey<Pinia>


### PR DESCRIPTION
In my project, I utilize Storybook for page development. The setup looks like this:
![image](https://github.com/user-attachments/assets/436a2fd4-60e8-42ff-b14f-9a9bb1799c95)

As you can see, two applications are displayed simultaneously within a single story. Each application has its own isolated logic layer.
I've implemented the logic layer using Pinia. However, to maintain isolation between the applications, I needed a way to create separate Pinia instances. To achieve this, I leveraged Vue's provide/inject system.
Here's how I implemented the Pinia provider:
typescript
```typescript
import { createPinia, piniaSymbol } from 'pinia';

export const PiniaProvider = defineComponent({
  name: 'PiniaProvider',
  props: {
    script: {
      type: Function,
    },
  },
  provide() {
    const pinia = createPinia();
    return {
      [piniaSymbol]: pinia,
    };
  },
  setup(props, context) {
    return () => (
      <ScriptExecutor script={props.script}>
        {context.slots.default ? context.slots.default() : null}
      </ScriptExecutor>
    );
  },
});
```

and I use it like this
```typescript
// Storybook story 文件
export const TwoAppsStory = () => (
  <div class="app-container">
    <PiniaProvider script={initSciprt1}>
      <App />
    </PiniaProvider>

    <PiniaProvider script={initSciprt2}>
      <App />
    </PiniaProvider>
  </div>
)
```

This approach allows me to create distinct Pinia instances for each application, ensuring that their state management remains isolated.
The reason I need Pinia to export the piniaSymbol is to use it as a key when providing the Pinia instance. This symbol serves as a unique identifier, allowing me to inject the correct Pinia instance into each application context."
This refined version provides a clearer explanation of your setup, the problem you were solving, and how you implemented the solution using Vue's provide/inject system and Pinia's piniaSymbol.

My English is not very good, but I hope you can understand the meaning I'm trying to convey.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed the Pinia instance symbol for advanced integrations, testing, and edge cases.
* **Documentation**
  * Added guidance and usage cautions for the exposed symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->