### PR TITLE
fix: trigger reactivity for shallowRef when using  object syntax

### DIFF
--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -224,8 +224,6 @@ describe('store.$patch', () => {
       setActivePinia(createPinia())
       return defineStore('shallowRef', () => {
         const counter = shallowRef({ count: 0 })
-        const counter2 = shallowRef({ count: 0 })
-        const counter3 = shallowRef({ count: 0 })
         const markedRaw = ref({
           marked: markRaw({ count: 0 }),
         })
@@ -237,8 +235,6 @@ describe('store.$patch', () => {
         return {
           markedRaw,
           counter,
-          counter2,
-          counter3,
           nestedCounter,
         }
       })()
@@ -293,11 +289,11 @@ describe('store.$patch', () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      watch(() => store.counter2.count, watcherSpy, { flush: 'sync' })
+      watch(() => store.counter.count, watcherSpy, { flush: 'sync' })
 
       watcherSpy.mockClear()
       store.$patch((state) => {
-        state.counter2 = { count: state.counter2.count + 1 }
+        state.counter = { count: state.counter.count + 1 }
       })
 
       expect(watcherSpy).toHaveBeenCalledTimes(1)
@@ -307,10 +303,10 @@ describe('store.$patch', () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      watch(() => store.counter3.count, watcherSpy, { flush: 'sync' })
+      watch(() => store.counter.count, watcherSpy, { flush: 'sync' })
 
       watcherSpy.mockClear()
-      store.counter3 = { count: 3 }
+      store.counter = { count: 3 }
 
       expect(watcherSpy).toHaveBeenCalledTimes(1)
     })
@@ -342,14 +338,14 @@ describe('store.$patch', () => {
       const watcherSpy2 = vi.fn()
 
       watch(() => store.counter.count, watcherSpy1, { flush: 'sync' })
-      watch(() => store.counter2.count, watcherSpy2, { flush: 'sync' })
+      watch(() => store.nestedCounter.simple, watcherSpy2, { flush: 'sync' })
 
       watcherSpy1.mockClear()
       watcherSpy2.mockClear()
 
       store.$patch({
         counter: { count: 10 },
-        counter2: { count: 20 },
+        nestedCounter: { nested: { count: 0 }, simple: 20 },
       })
 
       expect(watcherSpy1).toHaveBeenCalledTimes(1)

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { reactive, ref } from 'vue'
+import { describe, it, expect, vi } from 'vitest'
+import { reactive, ref, shallowRef, computed, nextTick, watchEffect } from 'vue'
 import { createPinia, defineStore, Pinia, setActivePinia } from '../src'
 
 describe('store.$patch', () => {
@@ -213,6 +213,190 @@ describe('store.$patch', () => {
       store.$patch({ item: store.arr[0] })
       expect(oldItem).toEqual({ a: 0, b: 0 })
       expect(store.item).toEqual({ a: 1, b: 1 })
+    })
+  })
+
+  describe('shallowRef reactivity', () => {
+    const useShallowRefStore = () => {
+      setActivePinia(createPinia())
+      return defineStore('shallowRef', () => {
+        const counter = shallowRef({ count: 0 })
+        const counter2 = shallowRef({ count: 0 })
+        const counter3 = shallowRef({ count: 0 })
+        const nestedCounter = shallowRef({
+          nested: { count: 0 },
+          simple: 1,
+        })
+
+        return { counter, counter2, counter3, nestedCounter }
+      })()
+    }
+
+    it('triggers reactivity when patching shallowRef with object syntax', async () => {
+      const store = useShallowRefStore()
+      const watcherSpy = vi.fn()
+
+      // Create a computed that depends on the shallowRef
+      const doubleCount = computed(() => store.counter.count * 2)
+
+      // Watch the computed to verify reactivity
+      const stopWatcher = watchEffect(() => {
+        watcherSpy(doubleCount.value)
+      })
+
+      expect(watcherSpy).toHaveBeenCalledWith(0)
+      watcherSpy.mockClear()
+
+      // Patch using object syntax - this should trigger reactivity
+      store.$patch({ counter: { count: 1 } })
+
+      await nextTick()
+
+      expect(store.counter.count).toBe(1)
+      expect(doubleCount.value).toBe(2)
+      expect(watcherSpy).toHaveBeenCalledWith(2)
+
+      stopWatcher()
+    })
+
+    it('triggers reactivity when patching nested properties in shallowRef', async () => {
+      const store = useShallowRefStore()
+      const watcherSpy = vi.fn()
+
+      const nestedCount = computed(() => store.nestedCounter.nested.count)
+
+      const stopWatcher = watchEffect(() => {
+        watcherSpy(nestedCount.value)
+      })
+
+      expect(watcherSpy).toHaveBeenCalledWith(0)
+      watcherSpy.mockClear()
+
+      // Patch nested properties
+      store.$patch({
+        nestedCounter: {
+          nested: { count: 5 },
+          simple: 2,
+        },
+      })
+
+      await nextTick()
+
+      expect(store.nestedCounter.nested.count).toBe(5)
+      expect(store.nestedCounter.simple).toBe(2)
+      expect(nestedCount.value).toBe(5)
+      expect(watcherSpy).toHaveBeenCalledWith(5)
+
+      stopWatcher()
+    })
+
+    it('works with function syntax (baseline test)', async () => {
+      const store = useShallowRefStore()
+      const watcherSpy = vi.fn()
+
+      const doubleCount = computed(() => store.counter2.count * 2)
+
+      const stopWatcher = watchEffect(() => {
+        watcherSpy(doubleCount.value)
+      })
+
+      expect(watcherSpy).toHaveBeenCalledWith(0)
+      watcherSpy.mockClear()
+
+      // Function syntax should work (this was already working)
+      store.$patch((state) => {
+        state.counter2 = { count: state.counter2.count + 1 }
+      })
+
+      await nextTick()
+
+      expect(store.counter2.count).toBe(1)
+      expect(doubleCount.value).toBe(2)
+      expect(watcherSpy).toHaveBeenCalledWith(2)
+
+      stopWatcher()
+    })
+
+    it('works with direct assignment (baseline test)', async () => {
+      const store = useShallowRefStore()
+      const watcherSpy = vi.fn()
+
+      const doubleCount = computed(() => store.counter3.count * 2)
+
+      const stopWatcher = watchEffect(() => {
+        watcherSpy(doubleCount.value)
+      })
+
+      expect(watcherSpy).toHaveBeenCalledWith(0)
+      watcherSpy.mockClear()
+
+      // Direct assignment should work (this was already working)
+      store.counter3 = { count: 3 }
+
+      await nextTick()
+
+      expect(store.counter3.count).toBe(3)
+      expect(doubleCount.value).toBe(6)
+      expect(watcherSpy).toHaveBeenCalledWith(6)
+
+      stopWatcher()
+    })
+
+    it('handles partial updates correctly', async () => {
+      const store = useShallowRefStore()
+
+      // Set initial state with multiple properties
+      store.nestedCounter = {
+        nested: { count: 10 },
+        simple: 20,
+      }
+
+      // Patch only one property
+      store.$patch({
+        nestedCounter: {
+          nested: { count: 15 },
+          // Note: simple is not included, should remain unchanged
+        },
+      })
+
+      expect(store.nestedCounter.nested.count).toBe(15)
+      expect(store.nestedCounter.simple).toBe(20) // Should remain unchanged
+    })
+
+    it('works with multiple shallowRefs in single patch', async () => {
+      const store = useShallowRefStore()
+      const watcherSpy1 = vi.fn()
+      const watcherSpy2 = vi.fn()
+
+      const count1 = computed(() => store.counter.count)
+      const count2 = computed(() => store.counter2.count)
+
+      const stopWatcher1 = watchEffect(() => {
+        watcherSpy1(count1.value)
+      })
+
+      const stopWatcher2 = watchEffect(() => {
+        watcherSpy2(count2.value)
+      })
+
+      watcherSpy1.mockClear()
+      watcherSpy2.mockClear()
+
+      // Patch multiple shallowRefs at once
+      store.$patch({
+        counter: { count: 10 },
+        counter2: { count: 20 },
+      })
+
+      await nextTick()
+
+      expect(store.counter.count).toBe(10)
+      expect(store.counter2.count).toBe(20)
+      expect(watcherSpy1).toHaveBeenCalledWith(10)
+      expect(watcherSpy2).toHaveBeenCalledWith(20)
+
+      stopWatcher1()
+      stopWatcher2()
     })
   })
 })

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { reactive, ref, shallowRef, computed, nextTick, watchEffect } from 'vue'
+import { reactive, ref, shallowRef, markRaw, watch } from 'vue'
 import { createPinia, defineStore, Pinia, setActivePinia } from '../src'
+import { mockWarn } from './vitest-mock-warn'
 
 describe('store.$patch', () => {
+  mockWarn()
+
   const useStore = () => {
     // create a new store
     setActivePinia(createPinia())
@@ -223,56 +226,59 @@ describe('store.$patch', () => {
         const counter = shallowRef({ count: 0 })
         const counter2 = shallowRef({ count: 0 })
         const counter3 = shallowRef({ count: 0 })
+        const markedRaw = ref({
+          marked: markRaw({ count: 0 }),
+        })
         const nestedCounter = shallowRef({
           nested: { count: 0 },
           simple: 1,
         })
 
-        return { counter, counter2, counter3, nestedCounter }
+        return {
+          markedRaw,
+          counter,
+          counter2,
+          counter3,
+          nestedCounter,
+        }
       })()
     }
+
+    it('does not trigger reactivity when patching marked raw', async () => {
+      const store = useShallowRefStore()
+      const markedSpy = vi.fn()
+      const nestedSpy = vi.fn()
+      watch(() => store.markedRaw.marked, markedSpy, {
+        flush: 'sync',
+        deep: true,
+      })
+      watch(() => store.markedRaw.marked.count, nestedSpy, { flush: 'sync' })
+      store.$patch({ markedRaw: { marked: { count: 1 } } })
+      expect(nestedSpy).toHaveBeenCalledTimes(0)
+      expect(markedSpy).toHaveBeenCalledTimes(0)
+    })
 
     it('triggers reactivity when patching shallowRef with object syntax', async () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      // Create a computed that depends on the shallowRef
-      const doubleCount = computed(() => store.counter.count * 2)
+      watch(() => store.counter.count, watcherSpy, { flush: 'sync' })
 
-      // Watch the computed to verify reactivity
-      const stopWatcher = watchEffect(() => {
-        watcherSpy(doubleCount.value)
-      })
-
-      expect(watcherSpy).toHaveBeenCalledWith(0)
       watcherSpy.mockClear()
-
-      // Patch using object syntax - this should trigger reactivity
       store.$patch({ counter: { count: 1 } })
 
-      await nextTick()
-
-      expect(store.counter.count).toBe(1)
-      expect(doubleCount.value).toBe(2)
-      expect(watcherSpy).toHaveBeenCalledWith(2)
-
-      stopWatcher()
+      expect(watcherSpy).toHaveBeenCalledTimes(1)
     })
 
     it('triggers reactivity when patching nested properties in shallowRef', async () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      const nestedCount = computed(() => store.nestedCounter.nested.count)
-
-      const stopWatcher = watchEffect(() => {
-        watcherSpy(nestedCount.value)
+      watch(() => store.nestedCounter.nested.count, watcherSpy, {
+        flush: 'sync',
       })
 
-      expect(watcherSpy).toHaveBeenCalledWith(0)
       watcherSpy.mockClear()
-
-      // Patch nested properties
       store.$patch({
         nestedCounter: {
           nested: { count: 5 },
@@ -280,66 +286,33 @@ describe('store.$patch', () => {
         },
       })
 
-      await nextTick()
-
-      expect(store.nestedCounter.nested.count).toBe(5)
-      expect(store.nestedCounter.simple).toBe(2)
-      expect(nestedCount.value).toBe(5)
-      expect(watcherSpy).toHaveBeenCalledWith(5)
-
-      stopWatcher()
+      expect(watcherSpy).toHaveBeenCalledTimes(1)
     })
 
     it('works with function syntax (baseline test)', async () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      const doubleCount = computed(() => store.counter2.count * 2)
+      watch(() => store.counter2.count, watcherSpy, { flush: 'sync' })
 
-      const stopWatcher = watchEffect(() => {
-        watcherSpy(doubleCount.value)
-      })
-
-      expect(watcherSpy).toHaveBeenCalledWith(0)
       watcherSpy.mockClear()
-
-      // Function syntax should work (this was already working)
       store.$patch((state) => {
         state.counter2 = { count: state.counter2.count + 1 }
       })
 
-      await nextTick()
-
-      expect(store.counter2.count).toBe(1)
-      expect(doubleCount.value).toBe(2)
-      expect(watcherSpy).toHaveBeenCalledWith(2)
-
-      stopWatcher()
+      expect(watcherSpy).toHaveBeenCalledTimes(1)
     })
 
     it('works with direct assignment (baseline test)', async () => {
       const store = useShallowRefStore()
       const watcherSpy = vi.fn()
 
-      const doubleCount = computed(() => store.counter3.count * 2)
+      watch(() => store.counter3.count, watcherSpy, { flush: 'sync' })
 
-      const stopWatcher = watchEffect(() => {
-        watcherSpy(doubleCount.value)
-      })
-
-      expect(watcherSpy).toHaveBeenCalledWith(0)
       watcherSpy.mockClear()
-
-      // Direct assignment should work (this was already working)
       store.counter3 = { count: 3 }
 
-      await nextTick()
-
-      expect(store.counter3.count).toBe(3)
-      expect(doubleCount.value).toBe(6)
-      expect(watcherSpy).toHaveBeenCalledWith(6)
-
-      stopWatcher()
+      expect(watcherSpy).toHaveBeenCalledTimes(1)
     })
 
     it('handles partial updates correctly', async () => {
@@ -368,35 +341,19 @@ describe('store.$patch', () => {
       const watcherSpy1 = vi.fn()
       const watcherSpy2 = vi.fn()
 
-      const count1 = computed(() => store.counter.count)
-      const count2 = computed(() => store.counter2.count)
-
-      const stopWatcher1 = watchEffect(() => {
-        watcherSpy1(count1.value)
-      })
-
-      const stopWatcher2 = watchEffect(() => {
-        watcherSpy2(count2.value)
-      })
+      watch(() => store.counter.count, watcherSpy1, { flush: 'sync' })
+      watch(() => store.counter2.count, watcherSpy2, { flush: 'sync' })
 
       watcherSpy1.mockClear()
       watcherSpy2.mockClear()
 
-      // Patch multiple shallowRefs at once
       store.$patch({
         counter: { count: 10 },
         counter2: { count: 20 },
       })
 
-      await nextTick()
-
-      expect(store.counter.count).toBe(10)
-      expect(store.counter2.count).toBe(20)
-      expect(watcherSpy1).toHaveBeenCalledWith(10)
-      expect(watcherSpy2).toHaveBeenCalledWith(20)
-
-      stopWatcher1()
-      stopWatcher2()
+      expect(watcherSpy1).toHaveBeenCalledTimes(1)
+      expect(watcherSpy2).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -296,9 +296,6 @@ function createSetupStore<
   // https://github.com/vuejs/pinia/issues/1129
   let activeListener: Symbol | undefined
 
-  // Store reference for shallowRef handling - will be set after setupStore creation
-  let setupStoreRef: any = null
-
   function $patch(stateMutation: (state: UnwrapRef<S>) => void): void
   function $patch(partialState: _DeepPartial<UnwrapRef<S>>): void
   function $patch(
@@ -323,24 +320,21 @@ function createSetupStore<
     } else {
       mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
 
-      // Handle shallowRef reactivity: check if any patched properties are shallowRefs
-      // and trigger their reactivity manually
-      if (setupStoreRef) {
-        const shallowRefsToTrigger: any[] = []
+      // Handle shallowRef reactivity: inspect raw store to avoid ref unwrapping
+      {
+        const rawStore = toRaw(store) as Record<string, unknown>
+        const shallowRefsToTrigger: Ref[] = []
         for (const key in partialStateOrMutator) {
-          if (partialStateOrMutator.hasOwnProperty(key)) {
-            // Check if the property in the setupStore is a shallowRef
-            const setupStoreProperty = setupStoreRef[key]
-            if (
-              isShallowRef(setupStoreProperty) &&
-              isPlainObject(partialStateOrMutator[key])
-            ) {
-              shallowRefsToTrigger.push(setupStoreProperty)
-            }
+          if (!Object.prototype.hasOwnProperty.call(partialStateOrMutator, key))
+            continue
+          const prop = (rawStore as any)[key]
+          if (
+            isShallowRef(prop) &&
+            isPlainObject((partialStateOrMutator as any)[key])
+          ) {
+            shallowRefsToTrigger.push(prop)
           }
         }
-
-        // Trigger reactivity for all shallowRefs that were patched
         shallowRefsToTrigger.forEach(triggerRef)
       }
 
@@ -531,8 +525,7 @@ function createSetupStore<
     pinia._e.run(() => (scope = effectScope()).run(() => setup({ action }))!)
   )!
 
-  // Set setupStore reference for shallowRef handling in $patch
-  setupStoreRef = setupStore
+  // no-op: `$patch` inspects refs via `toRaw(store)`
 
   // overwrite existing actions to support $onAction
   for (const key in setupStore) {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -90,14 +90,14 @@ function mergeReactiveObjects<
 
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!Object.prototype.hasOwnProperty.call(patchToApply, key)) continue
+    if (!patchToApply.hasOwnProperty(key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
 
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
-      Object.prototype.hasOwnProperty.call(target, key) &&
+      target.hasOwnProperty(key) &&
       !isRef(subPatch) &&
       !isReactive(subPatch)
     ) {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -11,6 +11,7 @@ import {
   markRaw,
   isRef,
   isReactive,
+  isShallow,
   effectScope,
   EffectScope,
   ComputedRef,
@@ -89,14 +90,14 @@ function mergeReactiveObjects<
 
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
-    if (!patchToApply.hasOwnProperty(key)) continue
+    if (!Object.prototype.hasOwnProperty.call(patchToApply, key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
 
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
-      target.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(target, key) &&
       !isRef(subPatch) &&
       !isReactive(subPatch)
     ) {
@@ -154,7 +155,7 @@ function isComputed(o: any): o is ComputedRef {
  * @returns true if the value is a shallowRef
  */
 function isShallowRef(value: any): value is Ref {
-  return isRef(value) && !!(value as any).__v_isShallow
+  return isRef(value) && isShallow(value)
 }
 
 function createOptionsStore<
@@ -524,8 +525,6 @@ function createSetupStore<
   const setupStore = runWithContext(() =>
     pinia._e.run(() => (scope = effectScope()).run(() => setup({ action }))!)
   )!
-
-  // no-op: `$patch` inspects refs via `toRaw(store)`
 
   // overwrite existing actions to support $onAction
   for (const key in setupStore) {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -5,35 +5,34 @@ import {
   hasInjectionContext,
   getCurrentInstance,
   reactive,
-  DebuggerEvent,
-  WatchOptions,
-  UnwrapRef,
   markRaw,
   isRef,
   isReactive,
   isShallow,
   effectScope,
-  EffectScope,
-  ComputedRef,
   toRaw,
   toRef,
   toRefs,
-  Ref,
   ref,
   nextTick,
   triggerRef,
+  type DebuggerEvent,
+  type WatchOptions,
+  type UnwrapRef,
+  type EffectScope,
+  type ComputedRef,
+  type ShallowRef,
+  type Ref,
 } from 'vue'
-import {
+import type {
+  _DeepPartial,
   StateTree,
   SubscriptionCallback,
-  _DeepPartial,
-  isPlainObject,
   Store,
   _Method,
   DefineStoreOptions,
   StoreDefinition,
   _GettersTree,
-  MutationType,
   StoreOnActionListener,
   _ActionsTree,
   SubscriptionCallbackMutation,
@@ -48,7 +47,13 @@ import {
   _ExtractStateFromSetupStore,
   _StoreWithState,
 } from './types'
-import { setActivePinia, piniaSymbol, Pinia, activePinia } from './rootStore'
+import { isPlainObject, MutationType } from './types'
+import {
+  setActivePinia,
+  piniaSymbol,
+  type Pinia,
+  activePinia,
+} from './rootStore'
 import { IS_CLIENT } from './env'
 import { patchObject } from './hmr'
 import { addSubscription, triggerSubscriptions, noop } from './subscriptions'
@@ -88,11 +93,14 @@ function mergeReactiveObjects<
     patchToApply.forEach(target.add, target)
   }
 
+  // the raw version lets us see shallow refs
+  const rawTarget = toRaw(target)
+
   // no need to go through symbols because they cannot be serialized anyway
   for (const key in patchToApply) {
     if (!patchToApply.hasOwnProperty(key)) continue
-    const subPatch = patchToApply[key]
-    const targetValue = target[key]
+    var subPatch = patchToApply[key]
+    var targetValue = target[key]
 
     if (
       isPlainObject(targetValue) &&
@@ -108,6 +116,11 @@ function mergeReactiveObjects<
     } else {
       // @ts-expect-error: subPatch is a valid value
       target[key] = subPatch
+    }
+
+    // enables $patching shallow refs
+    if (isShallow(rawTarget[key])) {
+      triggerRef(rawTarget[key] as ShallowRef)
     }
   }
 
@@ -147,15 +160,6 @@ const { assign } = Object
 function isComputed<T>(value: ComputedRef<T> | unknown): value is ComputedRef<T>
 function isComputed(o: any): o is ComputedRef {
   return !!(isRef(o) && (o as any).effect)
-}
-
-/**
- * Checks if a value is a shallowRef
- * @param value - value to check
- * @returns true if the value is a shallowRef
- */
-function isShallowRef(value: any): value is Ref {
-  return isRef(value) && isShallow(value)
 }
 
 function createOptionsStore<
@@ -320,24 +324,6 @@ function createSetupStore<
       }
     } else {
       mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
-
-      // Handle shallowRef reactivity: inspect raw store to avoid ref unwrapping
-      {
-        const rawStore = toRaw(store) as Record<string, unknown>
-        const shallowRefsToTrigger: Ref[] = []
-        for (const key in partialStateOrMutator) {
-          if (!Object.prototype.hasOwnProperty.call(partialStateOrMutator, key))
-            continue
-          const prop = (rawStore as any)[key]
-          if (
-            isShallowRef(prop) &&
-            isPlainObject((partialStateOrMutator as any)[key])
-          ) {
-            shallowRefsToTrigger.push(prop)
-          }
-        }
-        shallowRefsToTrigger.forEach(triggerRef)
-      }
 
       subscriptionMutation = {
         type: MutationType.patchObject,

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -20,6 +20,7 @@ import {
   Ref,
   ref,
   nextTick,
+  triggerRef,
 } from 'vue'
 import {
   StateTree,
@@ -91,6 +92,7 @@ function mergeReactiveObjects<
     if (!patchToApply.hasOwnProperty(key)) continue
     const subPatch = patchToApply[key]
     const targetValue = target[key]
+
     if (
       isPlainObject(targetValue) &&
       isPlainObject(subPatch) &&
@@ -144,6 +146,15 @@ const { assign } = Object
 function isComputed<T>(value: ComputedRef<T> | unknown): value is ComputedRef<T>
 function isComputed(o: any): o is ComputedRef {
   return !!(isRef(o) && (o as any).effect)
+}
+
+/**
+ * Checks if a value is a shallowRef
+ * @param value - value to check
+ * @returns true if the value is a shallowRef
+ */
+function isShallowRef(value: any): value is Ref {
+  return isRef(value) && !!(value as any).__v_isShallow
 }
 
 function createOptionsStore<
@@ -284,6 +295,10 @@ function createSetupStore<
   // avoid triggering too many listeners
   // https://github.com/vuejs/pinia/issues/1129
   let activeListener: Symbol | undefined
+
+  // Store reference for shallowRef handling - will be set after setupStore creation
+  let setupStoreRef: any = null
+
   function $patch(stateMutation: (state: UnwrapRef<S>) => void): void
   function $patch(partialState: _DeepPartial<UnwrapRef<S>>): void
   function $patch(
@@ -307,6 +322,28 @@ function createSetupStore<
       }
     } else {
       mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
+
+      // Handle shallowRef reactivity: check if any patched properties are shallowRefs
+      // and trigger their reactivity manually
+      if (setupStoreRef) {
+        const shallowRefsToTrigger: any[] = []
+        for (const key in partialStateOrMutator) {
+          if (partialStateOrMutator.hasOwnProperty(key)) {
+            // Check if the property in the setupStore is a shallowRef
+            const setupStoreProperty = setupStoreRef[key]
+            if (
+              isShallowRef(setupStoreProperty) &&
+              isPlainObject(partialStateOrMutator[key])
+            ) {
+              shallowRefsToTrigger.push(setupStoreProperty)
+            }
+          }
+        }
+
+        // Trigger reactivity for all shallowRefs that were patched
+        shallowRefsToTrigger.forEach(triggerRef)
+      }
+
       subscriptionMutation = {
         type: MutationType.patchObject,
         payload: partialStateOrMutator,
@@ -493,6 +530,9 @@ function createSetupStore<
   const setupStore = runWithContext(() =>
     pinia._e.run(() => (scope = effectScope()).run(() => setup({ action }))!)
   )!
+
+  // Set setupStore reference for shallowRef handling in $patch
+  setupStoreRef = setupStore
 
   // overwrite existing actions to support $onAction
   for (const key in setupStore) {


### PR DESCRIPTION
- Add triggerRef import from Vue
- Implement isShallowRef utility function to detect shallowRef using __v_isShallow
- Modify  method to detect shallowRef targets and trigger reactivity after patching
- Add comprehensive tests for shallowRef reactivity scenarios
- Ensure compatibility with existing patch behavior

close #2861

<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable reactivity for shallowRef state when using $patch — nested, partial, multi-field, and direct-assignment updates now consistently notify watchers and computed values; public APIs unchanged.

* **Tests**
  * Added comprehensive tests covering shallowRef behavior with object and function patch syntax, nested updates, partial/multi-ref patches, direct assignments, and reactivity observation to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->