### PR TITLE
fix: make settable getters (computed) editable

### DIFF
--- a/packages/pinia/src/devtools/formatting.ts
+++ b/packages/pinia/src/devtools/formatting.ts
@@ -153,7 +153,7 @@ export function formatStoreForInspectorState(
   // avoid adding empty getters
   if (store._getters && store._getters.length) {
     state.getters = store._getters.map((getterName) => ({
-      editable: false,
+      editable: !!store._editableComputed?.has(getterName),
       key: getterName,
       value: store[getterName],
     }))

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -261,18 +261,34 @@ export function registerPiniaDevtools(app: App, pinia: Pinia) {
 
           const { path } = payload
 
-          if (!isPinia(inspectedStore)) {
+          if (isPinia(inspectedStore)) {
+            const [storeId, computedKey] = path
+            const targetStore =
+              typeof storeId === 'string'
+                ? inspectedStore._s.get(storeId)
+                : undefined
+            const isEditableComputed =
+              path.length === 2 &&
+              !!targetStore &&
+              typeof computedKey === 'string' &&
+              targetStore._editableComputed?.has(computedKey)
+            if (!isEditableComputed) {
+              // Root access, we can omit the `.value` because the devtools API does it for us
+              path.unshift('state')
+            }
+          } else {
             // access only the state
+            const isEditableComputed =
+              path.length === 1 &&
+              inspectedStore._editableComputed?.has(path[0])
             if (
-              path.length !== 1 ||
-              !inspectedStore._customProperties.has(path[0]) ||
-              path[0] in inspectedStore.$state
+              !isEditableComputed &&
+              (path.length !== 1 ||
+                !inspectedStore._customProperties.has(path[0]) ||
+                path[0] in inspectedStore.$state)
             ) {
               path.unshift('$state')
             }
-          } else {
-            // Root access, we can omit the `.value` because the devtools API does it for us
-            path.unshift('state')
           }
           isTimelineActive = false
           payload.set(inspectedStore, path, payload.state.value)
@@ -290,6 +306,21 @@ export function registerPiniaDevtools(app: App, pinia: Pinia) {
           }
 
           const { path } = payload
+          if (path[0] === 'getters') {
+            const computedKey = path[1]
+            if (!computedKey || !store._editableComputed?.has(computedKey)) {
+              return toastMessage(
+                `Invalid path for store "${storeId}":\n${path}\nOnly writable computed properties can be modified.`
+              )
+            }
+
+            path.shift()
+            isTimelineActive = false
+            payload.set(store, path, payload.state.value)
+            isTimelineActive = true
+            return
+          }
+
           if (path[0] !== 'state') {
             return toastMessage(
               `Invalid path for store "${storeId}":\n${path}\nOnly state can be modified.`

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -11,6 +11,7 @@ import {
   markRaw,
   isRef,
   isReactive,
+  isReadonly,
   effectScope,
   EffectScope,
   ComputedRef,
@@ -471,6 +472,7 @@ function createSetupStore<
           {
             _hmrPayload,
             _customProperties: markRaw(new Set<string>()), // devtools custom properties
+            _editableComputed: markRaw(new Set<string>()), // devtools writable computed refs
           },
           partialStore
           // must be added later
@@ -549,6 +551,9 @@ function createSetupStore<
             // @ts-expect-error: same
             ((setupStore._getters = markRaw([])) as string[])
           getters.push(key)
+          if (!isReadonly(prop)) {
+            store._editableComputed?.add(key)
+          }
         }
       }
     }
@@ -666,6 +671,7 @@ function createSetupStore<
       // update the values used in devtools and to allow deleting new properties later on
       store._hmrPayload = newStore._hmrPayload
       store._getters = newStore._getters
+      store._editableComputed = newStore._editableComputed
       store._hotUpdating = false
     })
   }
@@ -679,15 +685,21 @@ function createSetupStore<
     }
 
     // avoid listing internal properties in devtools
-    ;(['_p', '_hmrPayload', '_getters', '_customProperties'] as const).forEach(
-      (p) => {
-        Object.defineProperty(
-          store,
-          p,
-          assign({ value: store[p] }, nonEnumerable)
-        )
-      }
-    )
+    const internalProperties = [
+      '_p',
+      '_hmrPayload',
+      '_getters',
+      '_editableComputed',
+      '_customProperties',
+    ] as const
+
+    internalProperties.forEach((p) => {
+      Object.defineProperty(
+        store,
+        p,
+        assign({ value: store[p] }, nonEnumerable)
+      )
+    })
   }
 
   // apply all plugins

--- a/packages/pinia/src/types.ts
+++ b/packages/pinia/src/types.ts
@@ -260,6 +260,14 @@ export interface StoreProperties<Id extends string> {
   _getters?: string[]
 
   /**
+   * Used by devtools plugin to track writable computed refs. Removed in
+   * production.
+   *
+   * @internal
+   */
+  _editableComputed?: Set<string>
+
+  /**
    * Used (and added) by devtools plugin to detect Setup vs Options API usage.
    *
    * @internal


### PR DESCRIPTION
`computed` values with both `get` and `set` could not be edited from pinia devtools before.

Example:

```ts
export const useVolumeStore = defineStore("volumeStore", () => {
  const rawVolume = ref(0.5);

  const round = (val: number) => Math.round(val * 100000) / 100000;

  const volume = computed({
    get: () => rawVolume.value,
    set: (value: number) => {
      rawVolume.value = round(Math.max(0, Math.min(1, value)));
    },
  });

  const output = computed(() => {
    if (volume.value < 0.01) return 0;

    const pow = Math.pow(volume.value, 2);

    return round(pow);
  });

  return { volume, output };
});
```

This change makes writable getters (computed) editable in the devtools while keeping readonly computed values readonly.

<img width="255" height="140" alt="Screenshot 2026-03-24 at 19 54 29" src="https://github.com/user-attachments/assets/54ef6a51-b604-4fe2-8393-fdb9d14f8950" />

# Summary by CodeRabbit

## Release Notes

- New Features
	- Pinia devtools inspector now enables direct editing of writable computed values. 
- Enhancements
	- Improved computed getter editability detection in the devtools inspector.
	- Enhanced state editing validation and error handling for computed properties.