### PR TITLE
docs: clarify `stubActions` limitations in Setup stores

### DIFF
--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -166,6 +166,65 @@ store.someAction()
 expect(store.someAction).toHaveBeenCalledTimes(1)
 ```
 
+### Stubbing limitations in Setup stores
+
+When using Setup stores (Composition API), internal calls between actions use closed-over function references rather than the store proxy. This means `stubActions` cannot intercept them, only external calls through the store instance are affected:
+
+```js
+// Setup store
+export const useCounterStore = defineStore('counter', () => {
+  function increment() {
+    /*...*/
+  }
+
+  function incrementTwice() {
+    increment() // ❌ internal call — NOT intercepted by stubActions
+    increment()
+  }
+
+  return { increment, incrementTwice }
+})
+
+const store = useCounterStore()
+store.increment() // ✅ stubbed — called through the store proxy
+store.incrementTwice() // ✅ stubbed — but its internal call to increment() will still run
+```
+
+Options API stores do not have this limitation because they use `this` for internal calls, which always goes through the store proxy:
+
+```js
+// Options store
+export const useCounterStore = defineStore('counter', {
+  actions: {
+    increment() {
+      /*...*/
+    },
+    incrementTwice() {
+      this.increment() // ✅ internal call — intercepted by stubActions
+      this.increment()
+    },
+  },
+})
+```
+
+If you need to test internal calls in a Setup store, the workaround is to call actions via the store proxy (e.g. `useStore().increment()`) instead of directly calling the function. This way, they will be affected by `stubActions` as expected.
+
+```js
+// Setup store with workaround
+export const useCounterStore = defineStore('counter', () => {
+  function increment() {
+    /*...*/
+  }
+
+  function incrementTwice() {
+    useCounterStore().increment() // ✅ call through the store proxy — will be stubbed
+    useCounterStore().increment()
+  }
+
+  return { increment, incrementTwice }
+})
+```
+
 ### Selective action stubbing
 
 Sometimes you may want to stub only specific actions while allowing others to execute normally. You can achieve this by passing an array of action names to the `stubActions` option:

--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -168,56 +168,53 @@ expect(store.someAction).toHaveBeenCalledTimes(1)
 
 ### Stubbing limitations in Setup stores
 
-When using Setup stores (Composition API), internal calls between actions use closed-over function references rather than the store proxy. This means `stubActions` cannot intercept them, only external calls through the store instance are affected:
+`stubActions` replaces actions on the store instance only. In a Setup store, an action that calls another action uses the closed-over function reference, not the store, so the stub is never used for that internal call:
 
 ```js
 // Setup store
 export const useCounterStore = defineStore('counter', () => {
   function increment() {
-    /*...*/
+    /* ... */
   }
 
   function incrementTwice() {
-    increment() // ❌ internal call — NOT intercepted by stubActions
+    increment() // ❌ closed-over reference, the stub is never used
     increment()
   }
 
   return { increment, incrementTwice }
 })
-
-const store = useCounterStore()
-store.increment() // ✅ stubbed — called through the store proxy
-store.incrementTwice() // ✅ stubbed — but its internal call to increment() will still run
 ```
 
-Options API stores do not have this limitation because they use `this` for internal calls, which always goes through the store proxy:
+Stubbing affects `store.increment()` but not the `increment()` calls inside `incrementTwice()`. Running the real `incrementTwice()` always runs the real `increment()`.
+
+Options stores don't have this limitation. Internal calls go through `this`, which is the store instance, so they hit the stub:
 
 ```js
 // Options store
 export const useCounterStore = defineStore('counter', {
   actions: {
     increment() {
-      /*...*/
+      /* ... */
     },
     incrementTwice() {
-      this.increment() // ✅ internal call — intercepted by stubActions
+      this.increment() // ✅ goes through the store, uses the stub
       this.increment()
     },
   },
 })
 ```
 
-If you need to test internal calls in a Setup store, the workaround is to call actions via the store proxy (e.g. `useStore().increment()`) instead of directly calling the function. This way, they will be affected by `stubActions` as expected.
+To make an internal call stubbable in a Setup store, route it through the store instead of the closed-over function:
 
 ```js
-// Setup store with workaround
 export const useCounterStore = defineStore('counter', () => {
   function increment() {
-    /*...*/
+    /* ... */
   }
 
   function incrementTwice() {
-    useCounterStore().increment() // ✅ call through the store proxy — will be stubbed
+    useCounterStore().increment() // ✅ goes through the store, uses the stub
     useCounterStore().increment()
   }
 

--- a/packages/docs/cookbook/testing.md
+++ b/packages/docs/cookbook/testing.md
@@ -205,6 +205,8 @@ export const useCounterStore = defineStore('counter', {
 })
 ```
 
+::: warning
+
 To make an internal call stubbable in a Setup store, route it through the store instead of the closed-over function:
 
 ```js
@@ -214,13 +216,18 @@ export const useCounterStore = defineStore('counter', () => {
   }
 
   function incrementTwice() {
-    useCounterStore().increment() // ✅ goes through the store, uses the stub
-    useCounterStore().increment()
+    const store = useCounterStore()
+    store.increment() // ✅ goes through the store, uses the stub
+    store.increment()
   }
 
   return { increment, incrementTwice }
 })
 ```
+
+This works but is _overkill_ just to satisfy a test, so reconsider if you really need to stub that action or if you can just test the real implementation instead first.
+
+:::
 
 ### Selective action stubbing
 


### PR DESCRIPTION
## Summary

- Documents that `stubActions` cannot intercept internal action calls in
  Setup stores, because they use closed-over references instead of the
  store proxy
- Contrasts with Options API stores where `this` always routes through
  the proxy, so internal calls are stubbed as expected
- Provides a workaround: call actions via `useStore()` inside the Setup
  store to make them interceptable by `stubActions`

## Motivation

This is a common source of confusion when testing Setup stores — tests
appear to stub an action but internal calls still execute. The existing
docs had no mention of this behaviour or how to work around it.


👤 PR code is human-generated by @dennybiasiolli
🤖 PR text generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how test action stubbing works differently for Setup (Composition API) vs Options API stores.
  * Explained the limitation around intercepting internal action-to-action calls in Setup stores.
  * Added before/after examples plus a workaround to route internal calls through the store proxy for reliable stubbing in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->