### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - 'packages/docs/**'
       - 'packages/playground/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -16,6 +16,9 @@ on:
       - 'packages/docs/**'
       - 'packages/playground/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'vuejs/pinia'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,6 +5,9 @@ on:
 
 name: Create Release
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Create Release


### PR DESCRIPTION
## Summary
- add explicit `permissions` blocks to CI and publish-preview workflows
- scope `GITHUB_TOKEN` to `contents: read`
- preserve existing install/build/test/release-preview behavior

## Why
This hardens workflow defaults by enforcing least privilege and making token scope explicit for future maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened automated workflow permissions: CI and publish workflows now limit repository content access to read, while the release workflow is granted content write permission to allow creating release tags.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/pinia/pull/3125)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->