### PR TITLE
fix: respect skipHydrate marker on non-plain objects in shouldHydrate

### DIFF
--- a/packages/pinia/__tests__/ssr.spec.ts
+++ b/packages/pinia/__tests__/ssr.spec.ts
@@ -8,6 +8,7 @@ import {
   getActivePinia,
   setActivePinia,
   shouldHydrate,
+  skipHydrate,
 } from '../src'
 import { Component, createSSRApp, inject, ref, computed, customRef } from 'vue'
 import { renderToString, ssrInterpolate } from '@vue/server-renderer'
@@ -170,6 +171,30 @@ describe('SSR', () => {
     expect(() => {
       shouldHydrate(obj)
     }).not.toThrow()
+  })
+
+  describe('shouldHydrate', () => {
+    it('returns true for unmarked plain objects', () => {
+      expect(shouldHydrate({})).toBe(true)
+      expect(shouldHydrate({ a: 1 })).toBe(true)
+    })
+
+    it('returns false for marked plain objects', () => {
+      expect(shouldHydrate(skipHydrate({}))).toBe(false)
+      expect(shouldHydrate(skipHydrate({ a: 1 }))).toBe(false)
+    })
+
+    it('returns false for marked non-plain objects', () => {
+      expect(shouldHydrate(skipHydrate(new Map()))).toBe(false)
+      expect(shouldHydrate(skipHydrate(new Set()))).toBe(false)
+      expect(shouldHydrate(skipHydrate([1, 2, 3]))).toBe(false)
+    })
+
+    it('returns true for nullish and primitive values', () => {
+      for (const value of [null, undefined, 0, 1, '', 'hello', false, true]) {
+        expect(shouldHydrate(value)).toBe(true)
+      }
+    })
   })
 
   it('errors if getActivePinia called outside of context', async () => {

--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -482,4 +482,70 @@ describe('State', () => {
       expect(spy).toHaveBeenCalledTimes(4)
     })
   })
+
+  describe('skipHydrate', () => {
+    it('skips hydration on a plain ref()', () => {
+      const pinia = createPinia()
+      pinia.state.value.main = { count: 24 }
+
+      setActivePinia(pinia)
+
+      const useMain = defineStore('main', () => ({
+        count: skipHydrate(ref(0)),
+      }))
+
+      const main = useMain()
+
+      // 0 because hydration was skipped
+      expect(main.count).toBe(0)
+      main.count++
+      expect(main.count).toBe(1)
+      main.$state.count++
+      expect(main.count).toBe(2)
+      main.$patch({ count: 0 })
+      expect(main.count).toBe(0)
+      main.$patch((state) => {
+        state.count++
+      })
+      expect(main.count).toBe(1)
+    })
+
+    it('skips hydration on a reactive object', () => {
+      const pinia = createPinia()
+      pinia.state.value.main = { obj: { value: 24 } }
+
+      setActivePinia(pinia)
+
+      const useMain = defineStore('main', () => ({
+        obj: skipHydrate(reactive({ value: 0 })),
+      }))
+
+      const main = useMain()
+
+      // 0 because hydration was skipped
+      expect(main.obj.value).toBe(0)
+      main.obj.value++
+      expect(main.obj.value).toBe(1)
+      main.$patch({ obj: { value: 5 } })
+      expect(main.obj.value).toBe(5)
+    })
+
+    it('skips hydration on a reactive Map', () => {
+      const pinia = createPinia()
+      pinia.state.value.main = { items: new Map([['a', 1]]) }
+
+      setActivePinia(pinia)
+
+      const useMain = defineStore('main', () => ({
+        items: skipHydrate(reactive(new Map<string, number>())),
+      }))
+
+      const main = useMain()
+
+      // empty because hydration was skipped on a non-plain reactive container
+      expect(main.items.size).toBe(0)
+      main.items.set('b', 2)
+      expect(main.items.get('b')).toBe(2)
+    })
+  })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -133,7 +133,9 @@ export function skipHydrate<T = any>(obj: T): T {
  * @returns true if `obj` should be hydrated
  */
 export function shouldHydrate(obj: any) {
-  return !isPlainObject(obj) || !Object.hasOwn(obj, skipHydrateSymbol)
+  return (
+    !obj || typeof obj !== 'object' || !Object.hasOwn(obj, skipHydrateSymbol)
+  )
 }
 
 const { assign } = Object


### PR DESCRIPTION
## Audit findings

While auditing the existing `skipHydrate` / `shouldHydrate` opt-out mechanism against an end-to-end SSR scenario, we found that the predicate was **too restrictive**: the marker was silently ignored on any value that is not a plain object.

The predicate at `packages/pinia/src/store.ts:135-137` was:

```ts
export function shouldHydrate(obj: any) {
  return !isPlainObject(obj) || !Object.hasOwn(obj, skipHydrateSymbol)
}
```

`isPlainObject` (defined at `packages/pinia/src/types.ts:16-29`) only accepts values whose `Object.prototype.toString` tag is `[object Object]`. That excludes reactive `Map` / `Set`, arrays, class instances, and other non-plain reactive containers. Because the predicate short-circuited to `true` (“do hydrate”) for any of these, calling `skipHydrate(reactive(new Map()))` (or similar) had **no effect** — the marker was set on the object, but the SSR payload still overwrote it during client-side hydration.

The rest of the contract (identity preservation, public exports, Nuxt integration at `packages/nuxt/src/runtime/payload-plugin.ts:7,16`, TypeScript typing `<T>(obj: T): T`) was already in place and correct.

## Fix

Broaden `shouldHydrate` so the marker is honoured on any non-null object, while keeping null/primitive safety so `Object.hasOwn` is never invoked on a non-object:

```ts
export function shouldHydrate(obj: any) {
  return (
    !obj || typeof obj !== 'object' || !Object.hasOwn(obj, skipHydrateSymbol)
  )
}
```

Notes:

- Behaviour for unmarked values is unchanged (always hydrate).
- Behaviour for marked plain objects, refs, and customRefs is unchanged.
- New behaviour: marked non-plain objects (arrays, `Map`, `Set`, class instances) are now correctly skipped.
- The `Object.create(null)` safety test at `packages/pinia/__tests__/ssr.spec.ts:168-173` still passes — `Object.hasOwn` works on null-prototype objects.
- No change needed in `createSetupStore` (the gate at `store.ts:506` keeps using `shouldHydrate`) or in the Nuxt payload reducer; both inherit the broader semantics for free.

The `isPlainObject` import in `store.ts` is retained because `mergeReactiveObjects` still uses it (lines 95-96, 592-593).

## Tests added

**`packages/pinia/__tests__/state.spec.ts`** — new `describe('skipHydrate', ...)` block with three integration cases that pre-seed `pinia.state.value` and assert hydration is skipped while mutations still work:

- `skipHydrate(ref(0))` on a plain ref
- `skipHydrate(reactive({ value: 0 }))` on a reactive object
- `skipHydrate(reactive(new Map()))` — regression test for the gap above; fails without the fix

**`packages/pinia/__tests__/ssr.spec.ts`** — new `describe('shouldHydrate', ...)` block with focused predicate unit tests:

- returns `true` for unmarked plain objects
- returns `false` for marked plain objects
- returns `false` for marked non-plain objects (`Map`, `Set`, array)
- returns `true` for nullish and primitive values

## Test plan

- [x] `pnpm test:vitest run packages/pinia/__tests__/state.spec.ts packages/pinia/__tests__/ssr.spec.ts` — 2 files, 38 passed, 1 skipped (pre-existing nested-marker TODO)
- [x] `pnpm test:vitest run packages/pinia/` — 27 files, 202 passed, 3 skipped, 4 todo, no type errors, no regressions
- [x] Verified `Object.create(null)` test (`ssr.spec.ts:168-173`) still passes with the new predicate
- [x] Verified the Nuxt payload reducer at `packages/nuxt/src/runtime/payload-plugin.ts:16` benefits from the broader semantics with no code change required

## Out of scope

- The nested `skipHydrate()` limitation documented by the skipped test at `packages/pinia/__tests__/state.spec.ts:457-483` is intentionally left for a follow-up — it requires either a recursive traversal or a dev-time warning, both larger than this targeted fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for hydration skip behavior across various state shapes (refs, reactive objects, Maps).

* **Bug Fixes**
  * Enhanced hydration skip to work with all object types, not just plain objects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vuejs/pinia/pull/3126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->