### PR TITLE
docs: add missing comma between mapState spreads in the Options API example

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -163,7 +163,7 @@ export default {
   computed: {
     // gives access to this.count inside the component
     // same as reading from store.count
-    ...mapState(useCounterStore, ['count'])
+    ...mapState(useCounterStore, ['count']),
     // same as above but registers it as this.myOwnName
     ...mapState(useCounterStore, {
       myOwnName: 'count',


### PR DESCRIPTION
## Summary

The Options API `mapState()` example in `core-concepts/state.md` is missing a comma between its two object-spread `computed` entries:

```js
computed: {
  ...mapState(useCounterStore, ['count'])
  // same as above but registers it as this.myOwnName
  ...mapState(useCounterStore, {
    ...
  }),
},
```

Two spread elements in an object literal with no comma between them is a hard `SyntaxError`. Verified with `node --check`: the snippet throws `SyntaxError: Unexpected token '...'` at the second `...mapState(...)`, so anyone copying this example verbatim cannot run it.

## Change

Add the missing trailing comma after `...mapState(useCounterStore, ['count'])`. After the fix, `node --check` parses the example cleanly. One-character, docs-only change; no semantics altered.

The same fix was already applied to the Chinese translation of this file in #3102 — this brings the English source in line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples in core concepts documentation to improve formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->