### PR TITLE
fix(hmr): preserve runtime-added properties of setup store refs

### DIFF
--- a/packages/pinia/__tests__/hmr.spec.ts
+++ b/packages/pinia/__tests__/hmr.spec.ts
@@ -172,7 +172,52 @@ describe('HMR', () => {
         expect($stateSpy).toHaveBeenCalledTimes(4)
       })
 
-      it.todo('handles nested objects updates')
+      it('keeps runtime-added properties of a ref object (#2611)', () => {
+        const setup = () => {
+          const counter = ref<{ nr: number; sign?: 'positive' | 'negative' }>({
+            nr: 0,
+          })
+          function increment() {
+            counter.value.nr++
+            counter.value.sign = counter.value.nr > 0 ? 'positive' : 'negative'
+          }
+          return { counter, increment }
+        }
+
+        const useStore = defineStore('id', setup)
+        const store: any = useStore()
+        store.increment()
+        expect(store.$state).toEqual({ counter: { nr: 1, sign: 'positive' } })
+
+        // simulate a hmr with the same definition: the new module reinitializes
+        // `counter` to `{ nr: 0 }`, without the optional `sign` property
+        defineStore('id', setup)(null, store)
+
+        // both the explicitly defined `nr` and the runtime-added `sign` must be
+        // preserved
+        expect(store.$state).toEqual({ counter: { nr: 1, sign: 'positive' } })
+        expect(store.counter).toEqual({ nr: 1, sign: 'positive' })
+      })
+
+      it('handles nested objects updates', () => {
+        const setup = () => {
+          const nested = ref({ a: 'a', b: 'b' })
+          return { nested }
+        }
+
+        const useStore = defineStore('id', setup)
+        const store: any = useStore()
+        store.nested.a = 'changed'
+
+        // simulate a hmr that removes the `a` key from the definition
+        defineStore('id', () => {
+          const nested = ref<{ a?: string; b: string }>({ b: 'b' })
+          return { nested }
+        })(null, store)
+
+        // the runtime value of the ref is preserved as a whole
+        expect(store.$state).toEqual({ nested: { a: 'changed', b: 'b' } })
+      })
     })
 
     describe('actions', () => {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -590,6 +590,13 @@ function createSetupStore<
           const newStateTarget = newStore.$state[stateKey]
           const oldStateSource = store.$state[stateKey as keyof UnwrapRef<S>]
           if (
+            // option stores declare their whole state shape upfront, so a
+            // missing key means it was intentionally removed and `patchObject`
+            // reconciles the old state against the new shape. Setup stores
+            // create their state imperatively (e.g. `ref({})`) and properties
+            // can be added at runtime, so the old value must be transferred as
+            // a whole to avoid dropping them (#2611).
+            isOptionsStore &&
             typeof newStateTarget === 'object' &&
             isPlainObject(newStateTarget) &&
             isPlainObject(oldStateSource)


### PR DESCRIPTION
Closes #2611

## Problem

In a setup store, state created with `ref({ ... })` can gain new properties at runtime — e.g. an action that sets an optional field:

```ts
export const useCounterStore = defineStore('counter', () => {
  const counter = ref<{ nr: number; sign?: 'positive' | 'negative' }>({ nr: 0 })
  function increment() {
    counter.value.nr++
    counter.value.sign = counter.value.nr > 0 ? 'positive' : 'negative'
  }
  return { counter, increment }
})
```

After clicking *increment*, `counter` is `{ nr: 1, sign: 'positive' }`. On HMR, the new module reinitializes `counter` to its declared value `{ nr: 0 }` (no `sign`). `acceptHMRUpdate` then called `patchObject(newValue, oldValue)`, which **removes any key not present in the new value** — so the runtime-added `sign` was dropped, even though `nr` was preserved.

## Fix

`patchObject`'s removal semantics are correct for **option stores**, whose entire state shape is declared upfront in `state()`: a key missing from the new definition was intentionally removed. But **setup stores** build their state imperatively (`ref({})`, `reactive({})`), and properties may be added at runtime that were never part of any declaration — diffing them against the freshly-initialized value wrongly removes them.

The one-line change gates `patchObject` behind `isOptionsStore`. For setup stores the old value is transferred as a whole (the `else` branch already does exactly this — "transfer the ref" — for primitive/non-plain-object refs), which is also consistent with how the function form of `$patch` and direct assignment behave.

## Tests

`it.todo('handles nested objects updates')` in the setup-store block is replaced with two real tests:

- `keeps runtime-added properties of a ref object (#2611)` — the exact reported scenario.
- `handles nested objects updates` — a runtime-mutated nested value survives HMR even when the new definition drops a key.

Both fail before the change and pass after. The existing option-store tests (`patches nested objects`, `skips arrays`, `skips nested arrays`) are unchanged and still pass — removal behavior for option stores is preserved. Full suite: 204 passing.



## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hot module reload (HMR) behavior to preserve store properties added at runtime and maintain nested object values during module updates.
- **Tests**
  - Added coverage for HMR preservation of runtime-added properties and nested object changes.

