### PR TITLE
feat: gracefully skip nullish values in storeToRefs

### DIFF
--- a/packages/pinia/__tests__/storeToRefs.spec.ts
+++ b/packages/pinia/__tests__/storeToRefs.spec.ts
@@ -200,6 +200,23 @@ describe('storeToRefs', () => {
     expect(spy).toHaveBeenCalledTimes(0)
   })
 
+  it('does not crash when setup store returns null non-ref value', () => {
+    // A setup store may return a plain (non-ref) null value for optional state.
+    // storeToRefs must skip those gracefully instead of throwing
+    // TypeError: Cannot read properties of null (reading 'effect').
+    const useStore = defineStore('null-val', () => {
+      return {
+        nullableItem: null as null | { id: number },
+        text: ref('hello'),
+      }
+    })
+
+    const store = useStore()
+    expect(() => storeToRefs(store)).not.toThrow()
+    const { text } = storeToRefs(store)
+    expect(text.value).toBe('hello')
+  })
+
   tds(() => {
     const store1 = defineStore('a', () => {
       const n = ref(0)

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -94,7 +94,7 @@ export function storeToRefs<SS extends StoreGeneric>(
     const value = rawStore[key]
     // There is no native method to check for a computed
     // https://github.com/vuejs/core/pull/4165
-    if (value && value.effect) {
+    if (value?.effect) {
       // @ts-expect-error: too hard to type correctly
       refs[key] =
         // ...

--- a/packages/pinia/src/storeToRefs.ts
+++ b/packages/pinia/src/storeToRefs.ts
@@ -94,7 +94,7 @@ export function storeToRefs<SS extends StoreGeneric>(
     const value = rawStore[key]
     // There is no native method to check for a computed
     // https://github.com/vuejs/core/pull/4165
-    if (value.effect) {
+    if (value && value.effect) {
       // @ts-expect-error: too hard to type correctly
       refs[key] =
         // ...


### PR DESCRIPTION
## Bug

`storeToRefs` throws `TypeError: Cannot read properties of null (reading 'effect')` when a setup store returns a non-ref `null` value as part of its state (closes #3123).

```ts
const useStore = defineStore('example', () => {
  return {
    // non-ref null is valid for optional state
    nullableItem: null as { id: number } | null,
    text: ref('hello'),
  }
})
// Before this fix: TypeError: Cannot read properties of null (reading 'effect')
const { text } = storeToRefs(useStore())
```

The loop in `storeToRefs` iterates all enumerable keys in the raw store. When a setup store returns a raw `null` value (not wrapped in `ref()`), `rawStore[key]` is literally `null`, and the unguarded `value.effect` access throws.

## Fix

Add a null-guard before the `.effect` access:

```diff
- if (value.effect) {
+ if (value && value.effect) {
```

The guard is consistent with how `isRef` and `isReactive` already handle nullish values. A null (or undefined) raw value is simply skipped — the same outcome as any other non-ref, non-reactive value.

## Verification

```
pnpm vitest run --project pinia packages/pinia/__tests__/storeToRefs.spec.ts
# → Tests 10 passed (10)
```

Red (before): test failed with `TypeError: Cannot read properties of null (reading 'effect')`
Green (after): all 10 storeToRefs tests pass, including the new regression test.

> *This PR was developed with AI assistance.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `storeToRefs` could throw when a setup store includes optional state values that are `null` (non-ref).
  * Updated detection logic to safely handle nullish values before reading internal properties.

* **Tests**
  * Added coverage to ensure `storeToRefs` does not throw with `null` optional state and that existing refs are still returned and readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->