### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/packages/docs/getting-started.md
+++ b/packages/docs/getting-started.md
@@ -25,6 +25,10 @@ pnpm add pinia
 bun add pinia
 ```
 
+```bash [deno]
+deno add pinia
+```
+
 :::
 
 :::tip


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install `code-group` lists npm / yarn / pnpm / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno tab in parity:

```sh
deno add pinia
```

Docs-only change. Totally fine to close this if you'd rather not. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Deno as an installation option in the getting started guide, complementing existing package manager options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->