### PR TITLE
docs: mention `flush: 'sync'` caveat and perf impact

### DIFF
--- a/packages/docs/core-concepts/state.md
+++ b/packages/docs/core-concepts/state.md
@@ -277,6 +277,12 @@ cartStore.$subscribe((mutation, state) => {
 }, { flush: 'sync' })
 ```
 
+:::tip
+Note `flush: 'sync'` runs the callback after **every** state change rather than batching them, so it can have a performance impact if your subscription does heavy work or the state changes often.
+
+In a niche case, this also matters for correctness: a **direct** mutation (e.g. `store.count++`) happening synchronously right after a `$patch()` in the same tick won't trigger a non-sync subscription on its own. If you must be notified of every such mutation, use `flush: 'sync'`.
+:::
+
 ### Detaching subscriptions
 
 By default, _state subscriptions_ are bound to the component where they are added (if the store is inside a component's `setup()`). Meaning, they will be automatically removed when the component is unmounted. If you also want to keep them after the component is unmounted, pass `{ detached: true }` as the second argument to _detach_ the _state subscription_ from the current component:


### PR DESCRIPTION
Documents the niche `$subscribe` behavior where a direct mutation happening synchronously right after a `$patch()` in the same tick won't trigger a non-sync subscription, plus the performance trade-off of `flush: 'sync'`.

Closes #992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with detailed guidance on flush timing behavior, including how `flush: 'sync'` executes callbacks after every state change rather than batching, and potential performance implications in high-frequency scenarios.
  * Clarified edge case behavior for synchronous mutations following patch operations and their interaction with subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->