### PR TITLE
fix: support thenables in action hooks

### DIFF
--- a/packages/pinia/__tests__/onAction.spec.ts
+++ b/packages/pinia/__tests__/onAction.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { createPinia, defineStore, setActivePinia } from '../src'
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
+import { createContext, runInContext } from 'node:vm'
 
 describe('Subscriptions', () => {
   const useStore = () => {
@@ -26,6 +27,20 @@ describe('Subscriptions', () => {
         async asyncUpperName() {
           return this.user.toUpperCase()
         },
+        thenableUpperName() {
+          const result = this.user.toUpperCase()
+          return {
+            then(resolve: (value: string) => void) {
+              resolve(result)
+            },
+          }
+        },
+        crossRealmUpperName() {
+          return runInContext(
+            'Promise.resolve(value)',
+            createContext({ value: this.user.toUpperCase() })
+          ) as Promise<string>
+        },
         upperName() {
           return this.user.toUpperCase()
         },
@@ -34,6 +49,16 @@ describe('Subscriptions', () => {
         },
         async rejects(e: any) {
           throw e
+        },
+        rejectsWithThenable(e: any) {
+          return {
+            then(
+              _resolve: (value: unknown) => void,
+              reject: (reason: unknown) => void
+            ) {
+              reject(e)
+            },
+          }
         },
       },
     })()
@@ -100,12 +125,32 @@ describe('Subscriptions', () => {
     expect(spy).toHaveBeenCalledWith('EDUARDO')
   })
 
-  it('calls after with the resolved value', async () => {
+  it('calls after with the resolved value from a native Promise', async () => {
     const spy = vi.fn()
     store.$onAction(({ after }) => {
       after(spy)
     })
     await expect(store.asyncUpperName()).resolves.toBe('EDUARDO')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('EDUARDO')
+  })
+
+  it('calls after with the resolved value from a custom thenable', async () => {
+    const spy = vi.fn()
+    store.$onAction(({ after }) => {
+      after(spy)
+    })
+    await expect(store.thenableUpperName()).resolves.toBe('EDUARDO')
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('EDUARDO')
+  })
+
+  it('calls after with the resolved value from a cross-realm Promise', async () => {
+    const spy = vi.fn()
+    store.$onAction(({ after }) => {
+      after(spy)
+    })
+    await expect(store.crossRealmUpperName()).resolves.toBe('EDUARDO')
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith('EDUARDO')
   })
@@ -129,6 +174,20 @@ describe('Subscriptions', () => {
     await expect(store.rejects('fail')).rejects.toBe('fail')
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith('fail')
+  })
+
+  it('calls onError when a custom thenable rejects', async () => {
+    const afterSpy = vi.fn()
+    const onErrorSpy = vi.fn()
+    expect.assertions(4)
+    store.$onAction(({ after, onError }) => {
+      after(afterSpy)
+      onError(onErrorSpy)
+    })
+    await expect(store.rejectsWithThenable('fail')).rejects.toBe('fail')
+    expect(afterSpy).not.toHaveBeenCalled()
+    expect(onErrorSpy).toHaveBeenCalledTimes(1)
+    expect(onErrorSpy).toHaveBeenCalledWith('fail')
   })
 
   it('listeners are not affected when unsubscribe is called multiple times', () => {

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -56,6 +56,12 @@ const fallbackRunWithContext = (fn: () => unknown) => fn()
 
 type _SetType<AT> = AT extends Set<infer T> ? T : never
 
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value != null && typeof (value as PromiseLike<unknown>).then === 'function'
+  )
+}
+
 /**
  * Marks a function as an action for `$onAction`
  * @internal
@@ -396,8 +402,8 @@ function createSetupStore<
         throw error
       }
 
-      if (ret instanceof Promise) {
-        return ret
+      if (isPromiseLike(ret)) {
+        return Promise.resolve(ret)
           .then((value) => {
             triggerSubscriptions(afterCallbackSet, value)
             return value


### PR DESCRIPTION
## Summary

- Treat promise-like action returns as async results for `$onAction` subscribers.
- Use `Promise.resolve()` to assimilate thenables before triggering `after` or `onError` hooks.
- Add coverage for native promises, custom thenables, rejected thenables, and cross-realm promises.

## Root cause

The action wrapper only checked `ret instanceof Promise`, so promise-like objects and promises created in another realm skipped the async hook path. That meant `after` could receive the unresolved object and `onError` could miss rejected thenables.

## Validation

- `pnpm vitest run packages/pinia/__tests__/onAction.spec.ts`
- `pnpm run test:types`
- `pnpm exec oxfmt --check packages/pinia/src/store.ts packages/pinia/__tests__/onAction.spec.ts`
- `pnpm run test:vitest run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved action subscription handling to properly recognize and normalize promise-like return values, ensuring consistent behavior across different Promise implementations and contexts.

* **Tests**
  * Expanded test coverage for action return and rejection handling with custom thenables and cross-realm Promises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->