### PR TITLE
fix: trigger reactivity when $patch merges into a shallowRef state property

### DIFF
--- a/packages/pinia/__tests__/patch-shallowRef.spec.ts
+++ b/packages/pinia/__tests__/patch-shallowRef.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression test for https://github.com/vuejs/pinia/issues/2861
+ * $patch with an object partial does not trigger reactivity when the
+ * patched state property is backed by a shallowRef.
+ */
+import { describe, it, expect } from 'vitest'
+import { shallowRef, watchEffect, nextTick } from 'vue'
+import { createPinia, defineStore, setActivePinia } from '../src'
+
+describe('$patch + shallowRef reactivity (#2861)', () => {
+  it('triggers reactive effects when patching a shallowRef state property', async () => {
+    setActivePinia(createPinia())
+
+    const useStore = defineStore('shallowRefPatch', () => {
+      const counter = shallowRef({ count: 0 })
+      return { counter }
+    })
+
+    const store = useStore()
+
+    const captured: number[] = []
+    watchEffect(() => {
+      captured.push(store.counter.count)
+    })
+    // initial effect run
+    expect(captured).toEqual([0])
+
+    store.$patch({ counter: { count: 1 } })
+    await nextTick()
+
+    // effect must re-run because the shallowRef was changed via $patch
+    expect(store.counter.count).toBe(1)
+    expect(captured).toEqual([0, 1])
+  })
+
+  it('state value is correctly updated after patching a shallowRef', () => {
+    setActivePinia(createPinia())
+
+    const useStore = defineStore('shallowRefPatch2', () => {
+      const item = shallowRef({ name: 'foo', value: 0 })
+      return { item }
+    })
+
+    const store = useStore()
+
+    store.$patch({ item: { name: 'bar', value: 42 } })
+
+    expect(store.item.name).toBe('bar')
+    expect(store.item.value).toBe(42)
+  })
+})

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -20,6 +20,8 @@ import {
   Ref,
   ref,
   nextTick,
+  isShallow,
+  triggerRef,
 } from 'vue'
 import {
   StateTree,
@@ -103,6 +105,14 @@ function mergeReactiveObjects<
       // start the value of a property as a certain type e.g. a Map, and then for some reason, during SSR, change that
       // to `undefined`. When trying to hydrate, we want to override the Map with `undefined`.
       target[key] = mergeReactiveObjects(targetValue, subPatch)
+      // If the underlying reactive property is a shallow ref, mutating its inner
+      // object in-place won't trigger reactivity automatically (shallowRef only
+      // tracks reference identity, not deep properties). Call triggerRef to
+      // force dependent effects to re-run. See: https://github.com/vuejs/pinia/issues/2861
+      const rawRef = toRaw(target as Record<string | symbol, unknown>)[key]
+      if (isRef(rawRef) && isShallow(rawRef)) {
+        triggerRef(rawRef)
+      }
     } else {
       // @ts-expect-error: subPatch is a valid value
       target[key] = subPatch


### PR DESCRIPTION
## Problem

When a setup store has a `shallowRef` state property and `$patch` is called with a plain object, `mergeReactiveObjects` deep-merges **into the shallowRef's inner value in-place**. Because `shallowRef` only tracks reference identity (not deep property mutations), dependent reactive effects (watchers, `watchEffect`, computed, etc.) never re-run — even though the data was correctly updated in the store.

Reported in #2861. The maintainer confirmed the fix direction: call `triggerRef` when a shallow-ref-backed property is patched.

## Reproduction

```ts
const useStore = defineStore('test', () => {
  const counter = shallowRef({ count: 0 })
  return { counter }
})
const store = useStore()
const captured: number[] = []
watchEffect(() => { captured.push(store.counter.count) })
// captured = [0]

store.$patch({ counter: { count: 1 } })
await nextTick()
// Bug: captured still [0] — watchEffect did not re-run
// Expected: captured = [0, 1]
```

## Fix

After `mergeReactiveObjects` mutates the shallowRef's inner value in-place, retrieve the raw backing ref via `toRaw` and check `isRef` + `isShallow`. If both are true, call `triggerRef` to force dependent effects to re-run.

Changed files:
- `packages/pinia/src/store.ts` — add `isShallow`/`triggerRef` imports + the `triggerRef` call in `mergeReactiveObjects`
- `packages/pinia/__tests__/patch-shallowRef.spec.ts` — new regression tests (RED → GREEN)

## Verification

```
pnpm vitest run --project pinia
Test Files  18 passed (18)
Tests  202 passed | 3 skipped (205 total)
Type Errors  no errors
```

No existing test edited.

> AI-assisted contribution.

Closes #2861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `$patch` updates for state stored in shallow reactive references, so nested changes now reliably update the store.
  * Improved reactivity after patching nested objects, ensuring dependent views and effects refresh as expected.
  * Added regression coverage to protect this behavior in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->