### PR TITLE
fix($subscribe): prevent duplicate watcher when same callback subscribed twice

### DIFF
--- a/packages/pinia/__tests__/subscriptions.spec.ts
+++ b/packages/pinia/__tests__/subscriptions.spec.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { createPinia, defineStore, MutationType, setActivePinia } from '../src'
 import { mount } from '@vue/test-utils'
 import { nextTick, ref } from 'vue'
+import { mockWarn } from './vitest-mock-warn'
 
 describe('Subscriptions', () => {
+  mockWarn()
+
   const useOptionsStore = defineStore('main', {
     state: () => ({
       user: 'Eduardo',
@@ -376,30 +379,29 @@ describe('Subscriptions', () => {
       expect(postSpy).toHaveBeenCalledTimes(1)
     })
 
-    it('subscribing the same callback twice fires it only once per change', () => {
+    it('ignores a callback subscribed twice and warns', () => {
       const spy = vi.fn()
       const store = useStore()
       const unsub1 = store.$subscribe(spy, { flush: 'sync' })
       const unsub2 = store.$subscribe(spy, { flush: 'sync' })
 
-      // Direct state mutation: only one Set entry → one call expected
+      expect('passed to "$subscribe()"').toHaveBeenWarnedTimes(1)
+
       store.$state.user = 'once'
       expect(spy).toHaveBeenCalledTimes(1)
 
-      // $patch: triggerSubscriptions iterates the Set (one entry) → one call
       store.$patch({ user: 'twice' })
       expect(spy).toHaveBeenCalledTimes(2)
 
-      // Unsubscribing one of the duplicates removes the only Set entry,
-      // so the watcher should no longer fire the callback.
-      unsub1()
-      store.$state.user = 'after-unsub1'
-      expect(spy).toHaveBeenCalledTimes(2)
-
-      // Calling the second unsubscribe is a no-op (Set entry already gone).
+      // the second call returned a noop, so it does not unsubscribe anything
       unsub2()
       store.$state.user = 'after-unsub2'
-      expect(spy).toHaveBeenCalledTimes(2)
+      expect(spy).toHaveBeenCalledTimes(3)
+
+      // unsubscribing the original removes the single subscription
+      unsub1()
+      store.$state.user = 'after-unsub1'
+      expect(spy).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/packages/pinia/__tests__/subscriptions.spec.ts
+++ b/packages/pinia/__tests__/subscriptions.spec.ts
@@ -375,5 +375,31 @@ describe('Subscriptions', () => {
       expect(preSpy).toHaveBeenCalledTimes(1)
       expect(postSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('subscribing the same callback twice fires it only once per change', () => {
+      const spy = vi.fn()
+      const store = useStore()
+      const unsub1 = store.$subscribe(spy, { flush: 'sync' })
+      const unsub2 = store.$subscribe(spy, { flush: 'sync' })
+
+      // Direct state mutation: only one Set entry → one call expected
+      store.$state.user = 'once'
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // $patch: triggerSubscriptions iterates the Set (one entry) → one call
+      store.$patch({ user: 'twice' })
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      // Unsubscribing one of the duplicates removes the only Set entry,
+      // so the watcher should no longer fire the callback.
+      unsub1()
+      store.$state.user = 'after-unsub1'
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      // Calling the second unsubscribe is a no-op (Set entry already gone).
+      unsub2()
+      store.$state.user = 'after-unsub2'
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/packages/pinia/src/diagnostics.ts
+++ b/packages/pinia/src/diagnostics.ts
@@ -41,5 +41,11 @@ export const diagnostics = /*#__PURE__*/ defineDiagnostics({
       fix: 'If it should be reactive state, wrap it with ref(), reactive(), or shallowRef(). If it is an intentional non-reactive property, wrap it with markRaw() so storeToRefs() skips it explicitly.',
       docs: 'https://pinia.vuejs.org/core-concepts/plugins.html#Adding-new-external-properties',
     },
+    PINIA_R1007: {
+      why: (p: { id: string }) =>
+        `The same callback was passed to "$subscribe()" of store "${p.id}" more than once. Subscriptions are deduplicated, so the duplicate is ignored.`,
+      fix: 'Subscribe each callback only once. If you need to resubscribe, call the returned function to remove the previous subscription first, or create a new function.',
+      docs: 'https://pinia.vuejs.org/core-concepts/state.html#Subscribing-to-the-state',
+    },
   },
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -436,18 +436,14 @@ function createSetupStore<
     $patch,
     $reset,
     $subscribe(callback, options = {}) {
-      // The subscriptions Set deduplicates callbacks, so if the same
-      // function reference is already subscribed we must not create a
-      // second watcher.  Two watchers for a single Set-entry would
-      // invoke the callback twice on every direct state mutation while
-      // $patch (which uses triggerSubscriptions) correctly calls it
-      // only once — an inconsistency introduced when subscriptions were
-      // changed from an Array to a Set (PR #2887).
-      const alreadySubscribed = subscriptions.has(callback)
-
-      // Initialise to noop so the onCleanup closure is safe to call
-      // even in the duplicate case where no real watcher is created.
-      let stopWatcher: () => void = noop
+      // avoid setting up multiple watchers for the same callback
+      // https://github.com/vuejs/pinia/issues/3143
+      if (subscriptions.has(callback)) {
+        if (__DEV__) {
+          diagnostics.PINIA_R1007({ id: $id })
+        }
+        return noop
+      }
 
       const removeSubscription = addSubscription(
         subscriptions,
@@ -455,27 +451,24 @@ function createSetupStore<
         options.detached,
         () => stopWatcher()
       )
-
-      if (!alreadySubscribed) {
-        stopWatcher = scope.run(() =>
-          watch(
-            () => pinia.state.value[$id] as UnwrapRef<S>,
-            (state) => {
-              if (options.flush === 'sync' ? isSyncListening : isListening) {
-                callback(
-                  {
-                    storeId: $id,
-                    type: MutationType.direct,
-                    events: debuggerEvents as DebuggerEvent,
-                  },
-                  state
-                )
-              }
-            },
-            assign({}, $subscribeOptions, options)
-          )
-        )!
-      }
+      const stopWatcher = scope.run(() =>
+        watch(
+          () => pinia.state.value[$id] as UnwrapRef<S>,
+          (state) => {
+            if (options.flush === 'sync' ? isSyncListening : isListening) {
+              callback(
+                {
+                  storeId: $id,
+                  type: MutationType.direct,
+                  events: debuggerEvents as DebuggerEvent,
+                },
+                state
+              )
+            }
+          },
+          assign({}, $subscribeOptions, options)
+        )
+      )!
 
       return removeSubscription
     },

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -436,30 +436,46 @@ function createSetupStore<
     $patch,
     $reset,
     $subscribe(callback, options = {}) {
+      // The subscriptions Set deduplicates callbacks, so if the same
+      // function reference is already subscribed we must not create a
+      // second watcher.  Two watchers for a single Set-entry would
+      // invoke the callback twice on every direct state mutation while
+      // $patch (which uses triggerSubscriptions) correctly calls it
+      // only once — an inconsistency introduced when subscriptions were
+      // changed from an Array to a Set (PR #2887).
+      const alreadySubscribed = subscriptions.has(callback)
+
+      // Initialise to noop so the onCleanup closure is safe to call
+      // even in the duplicate case where no real watcher is created.
+      let stopWatcher: () => void = noop
+
       const removeSubscription = addSubscription(
         subscriptions,
         callback,
         options.detached,
         () => stopWatcher()
       )
-      const stopWatcher = scope.run(() =>
-        watch(
-          () => pinia.state.value[$id] as UnwrapRef<S>,
-          (state) => {
-            if (options.flush === 'sync' ? isSyncListening : isListening) {
-              callback(
-                {
-                  storeId: $id,
-                  type: MutationType.direct,
-                  events: debuggerEvents as DebuggerEvent,
-                },
-                state
-              )
-            }
-          },
-          assign({}, $subscribeOptions, options)
-        )
-      )!
+
+      if (!alreadySubscribed) {
+        stopWatcher = scope.run(() =>
+          watch(
+            () => pinia.state.value[$id] as UnwrapRef<S>,
+            (state) => {
+              if (options.flush === 'sync' ? isSyncListening : isListening) {
+                callback(
+                  {
+                    storeId: $id,
+                    type: MutationType.direct,
+                    events: debuggerEvents as DebuggerEvent,
+                  },
+                  state
+                )
+              }
+            },
+            assign({}, $subscribeOptions, options)
+          )
+        )!
+      }
 
       return removeSubscription
     },


### PR DESCRIPTION
Closes #3143

## Bug

When the same callback reference is passed to `$subscribe` more than once the subscriptions `Set` correctly stores it only once — so `$patch` (which iterates the Set via `triggerSubscriptions`) calls it only once. But `$subscribe` unconditionally created a new Vue `watch()` on every call, causing each watcher to fire the callback independently on direct state mutations (`store.prop = value`). N duplicate calls therefore produced N calls per mutation instead of one.

This inconsistency was introduced in #2887 when subscriptions were changed from an `Array` to a `Set`.

## Fix

Before calling `scope.run(() => watch(...))`, check whether the callback is already in the subscriptions Set. If it is, skip creating a new watcher. The `stopWatcher` variable is initialised to `noop` so the cleanup closure remains safe to call in the duplicate case.

## Verification


 RUN  v4.0.18 /tmp/oss-pr-loop3-20260616/pinia
      Coverage enabled with v8

 ✓ |pinia| __tests__/subscriptions.spec.ts (34 tests) 60ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
Type Errors  no errors
   Start at  12:19:16
   Duration  1.07s (transform 197ms, setup 284ms, import 37ms, tests 60ms, environment 288ms)

 % Coverage report from v8
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |   38.75 |    37.02 |    28.3 |   38.11 |                   
 pinia/src         |   45.63 |    44.25 |   32.96 |   44.76 |                   
  createPinia.ts   |   55.55 |    36.36 |      50 |      56 | 32,39-44,59,73-78 
  diagnostics.ts   |      20 |      100 |       0 |      20 | 18-40             
  env.ts           |     100 |      100 |     100 |     100 |                   
  global.d.ts      |       0 |        0 |       0 |       0 |                   
  ...Extensions.ts |       0 |        0 |       0 |       0 |                   
  mapHelpers.ts    |    5.71 |        0 |       0 |    5.71 | 76-286,397-550    
  rootStore.ts     |   44.44 |     6.66 |   33.33 |    37.5 | 49-57             
  store.ts         |      49 |    48.26 |   42.55 |   48.36 | ...73,898,925-934 
  storeToRefs.ts   |       0 |        0 |       0 |       0 | 90-115            
  subscriptions.ts |     100 |      100 |      80 |     100 |                   
  types.ts         |     100 |    66.66 |     100 |     100 | 24                
 testing/src       |       0 |        0 |       0 |       0 |                   
  diagnostics.ts   |       0 |      100 |     100 |       0 | 9                 
  ...oreGetters.ts |       0 |      100 |       0 |       0 | 15                
  testing.ts       |       0 |        0 |       0 |       0 | 113-282           
-------------------|---------|----------|---------|---------|-------------------

The new tests (one per store flavour via the existing `describe.each`) subscribe the same spy twice and assert:
1. Direct mutation fires spy **once**
2. `$patch` fires spy **once**
3. After unsubscribing, spy is not called again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate `store.$subscribe()` registrations so the same callback no longer fires more than once per mutation.
  * Ensured unsubscribe behavior is safe and does not affect remaining valid subscriptions.
* **New Features**
  * Added a dev-only diagnostic warning when the same callback is subscribed multiple times (with guidance to subscribe once or unsubscribe first).
* **Tests**
  * Expanded subscription coverage to verify warning behavior and correct callback/count handling for duplicate subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->