### PR TITLE
fix: reset removes added state keys

### DIFF
--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -195,6 +195,21 @@ describe('State', () => {
       },
     })
   })
+  it('removes added state keys when resetting the state', () => {
+    const store = useStore()
+    store.$patch({ added: 'value' } as any)
+
+    store.$reset()
+
+    expect(store.$state).toEqual({
+      counter: 0,
+      name: 'Eduardo',
+      nested: {
+        n: 0,
+      },
+    })
+    expect('added' in store.$state).toBe(false)
+  })
 
   it('can reset the state of an empty store', () => {
     const store = defineStore('a', {})(createPinia())

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -333,6 +333,11 @@ function createSetupStore<
         const newState: _DeepPartial<UnwrapRef<S>> = state ? state() : {}
         // we use a patch to group all changes into one single subscription
         this.$patch(($state) => {
+          for (const key in $state) {
+            if (!Object.hasOwn(newState, key)) {
+              delete $state[key]
+            }
+          }
           // @ts-expect-error: FIXME: shouldn't error?
           assign($state, newState)
         })


### PR DESCRIPTION
### Summary

- remove top-level state keys that are not present in the initial options-store state when `$reset()` runs
- add a focused regression test covering an added key left behind by `$reset()`

Closes #3145

### Tests

- `pnpm test:vitest run packages/pinia/__tests__/state.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting a setup store now fully restores its original state shape, removing any extra state keys that were added dynamically.
  * State reset updates are grouped more cleanly, so the reset behaves consistently as a single change.
* **Tests**
  * Added coverage to verify that dynamically added state is cleared when a store is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->