### PR TITLE
refactor: use `SetupStoreDefinition` for setup store overload

### DIFF
--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -846,12 +846,8 @@ export function defineStore<Id extends string, SS>(
     _ExtractGettersFromSetupStore<SS>,
     _ExtractActionsFromSetupStore<SS>
   >
-): StoreDefinition<
-  Id,
-  _ExtractStateFromSetupStore<SS>,
-  _ExtractGettersFromSetupStore<SS>,
-  _ExtractActionsFromSetupStore<SS>
->
+): SetupStoreDefinition<Id, SS>
+
 // allows unused stores to be tree shaken
 /*! #__NO_SIDE_EFFECTS__ */
 export function defineStore(


### PR DESCRIPTION
This avoids expanding the full `StoreDefinition` type in userland `.d.ts` output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript typing for setup-based stores, making store definitions resolve more reliably in editor tooling and type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->