### PR TITLE
docs: unwrap backticks of `@default` value

### DIFF
--- a/packages/nuxt/README.md
+++ b/packages/nuxt/README.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
      * also import nested stores, you can use the glob pattern `./stores/**`
      * (on Nuxt 3) or `app/stores/**` (on Nuxt 4+)
      *
-     * @default `['stores']`
+     * @default ['stores']
      */
     storesDirs: [],
   },

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -21,7 +21,7 @@ export interface ModuleOptions {
    * also import nested stores, you can use the glob pattern `stores/**`
    * (on Nuxt 3) or `app/stores/**` (on Nuxt 4+)
    *
-   * @default `['stores']`
+   * @default ['stores']
    */
   storesDirs?: string[]
 }

--- a/packages/testing/src/testing.ts
+++ b/packages/testing/src/testing.ts
@@ -39,7 +39,7 @@ export interface TestingOptions {
    * it will **only** make the `fn` argument `undefined`. You still have to
    * handle this in `createSpy()`.
    *
-   * @default `true`
+   * @default true
    */
   stubActions?:
     | boolean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default values in the configuration docs for store directories and testing action stubs.
  * Improved how default values are presented in the module and testing API documentation without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->