### PR TITLE
fix(exports): restore types condition in package exports

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -31,7 +31,10 @@
   "main": "./dist/module.mjs",
   "types": "./dist/module.d.mts",
   "exports": {
-    ".": "./dist/module.mjs"
+    ".": {
+      "types": "./dist/module.d.mts",
+      "default": "./dist/module.mjs"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -45,7 +45,10 @@
   "unpkg": "dist/pinia.iife.js",
   "jsdelivr": "dist/pinia.iife.js",
   "exports": {
-    ".": "./dist/pinia.mjs",
+    ".": {
+      "types": "./dist/pinia.d.ts",
+      "default": "./dist/pinia.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Restores the `types` condition in the `exports` map of `pinia` and `@pinia/nuxt`. This is a regression compared to Pinia v3.

## The regression

When CJS support was dropped in v4, the `exports` maps were simplified to point `.` directly at the ESM entry:

```json
"exports": {
  ".": "./dist/pinia.mjs"
}
```

This dropped the `types` condition. Under `moduleResolution: "bundler"` or `"nodenext"`, TypeScript resolves typings through the `exports` map, so it could no longer locate the declaration files, even though the top-level `types` field still pointed at them.

## Symptom

Consuming projects fail to compile with **TS7016**:

```
error TS7016: Could not find a declaration file for module 'pinia'.
'.../pinia/dist/pinia.mjs' implicitly has an 'any' type.
There are types at '.../pinia/dist/pinia.d.ts', but this result could not
be resolved when respecting package.json "exports".
```

## The fix

Re-add the `types` condition to the `.` subpath export, listed **first**. This is the required order: conditions are matched top down and `default` always matches, so a trailing `types` gets skipped by tools like publint / arethetypeswrong. This matches v3 behavior.

```json
"exports": {
  ".": {
    "types": "./dist/pinia.d.ts",
    "default": "./dist/pinia.mjs"
  },
  "./package.json": "./package.json"
}
```

Applied to both `packages/pinia` and `packages/nuxt`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved package metadata so TypeScript tooling can automatically locate the correct type declarations.
  * Preserved existing runtime module resolution for Nuxt and Pinia integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->