### PR TITLE
fix: Re-add missing types exports field

### DIFF
--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -45,7 +45,10 @@
   "unpkg": "dist/pinia.iife.js",
   "jsdelivr": "dist/pinia.iife.js",
   "exports": {
-    ".": "./dist/pinia.mjs",
+    ".": {
+      "types": "./dist/pinia.d.ts",
+      "import": "./dist/pinia.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Was erroneously removed in https://github.com/vuejs/pinia/commit/2ccb1843d6e07fd36d8186ad39093e54a437104f#diff-094e7966c93b0665e0587735e50e027a13cf910a52a14f06aa3528573ce15628L53, causing a missing type declarations error in TypeScript for consumers of 4.0.0.

Fixes #3153, #3152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package compatibility by exposing TypeScript type declarations alongside the main module entry point.
  * Enhanced editor and tooling support when importing the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->