### PR TITLE
fix: pinia@4.0.1 still not export of types

### DIFF
--- a/packages/pinia/tsdown.config.ts
+++ b/packages/pinia/tsdown.config.ts
@@ -31,7 +31,7 @@ const commonOptions = defineConfig({
 const esm = defineConfig({
   ...commonOptions,
   platform: 'neutral',
-  exports: true,
+  exports: false,
   dts: true,
   outputOptions: {
     entryFileNames: ({ name }) => `${name}.mjs`.replace('.d.mjs', '.d.ts'),


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

## Summar

It is tsdown option to it, exports set false, build have export of type

## I Found flow

By #3155

In pinia@4.0.1 still not export of type

<img width="522" height="261" alt="image" src="https://github.com/user-attachments/assets/8e64e69e-37b6-4ea5-8998-af4c4f9f830f" />

<img width="523" height="417" alt="image" src="https://github.com/user-attachments/assets/b0ad4f18-ed97-496c-803e-d78eebf3cc9c" />

but by #3154 fixed it, so not source code question, maybe bunder or npm pubic flow question?

I found use tsdown build pinia, package.json modify

<img width="1090" height="943" alt="image" src="https://github.com/user-attachments/assets/de6a3c45-c045-4451-a137-b64911986ffe" />

So I think the question at tsdown

<img width="772" height="224" alt="image" src="https://github.com/user-attachments/assets/ef7a8351-0d7d-49d0-8cda-509a363544c9" />

question is exports: true that option

<img width="834" height="567" alt="image" src="https://github.com/user-attachments/assets/b2c6145e-5940-4411-b92c-2dea2a44338f" />

because it modify package.json

<img width="1128" height="987" alt="image" src="https://github.com/user-attachments/assets/c92e4903-539f-458f-95f8-bf6ee70dcb9d" />

set false, this ok


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of the ESM build output with supported module environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->