### PR TITLE
fix(store): replace reactive Set/Map state on hydration instead of unioning it

### DIFF
--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -315,6 +315,26 @@ describe('State', () => {
     expect([...store.setReactive.values()]).toEqual([3, 4])
   })
 
+  it('replaces (does not union) a non-empty reactive Set/Map on hydration', async () => {
+    const useStore = defineStore('main', () => {
+      const setReactive = reactive(new Set(['default']))
+      const mapReactive = reactive(new Map([['x', 1]]))
+      return { setReactive, mapReactive }
+    })
+
+    const pinia = createPinia()
+    pinia.state.value.main = {
+      setReactive: new Set(['a']),
+      mapReactive: new Map([['y', 2]]),
+    }
+    setActivePinia(pinia)
+
+    const store = useStore()
+    // The server state is authoritative, so the default entries are gone.
+    expect([...store.setReactive.values()]).toEqual(['a'])
+    expect([...store.mapReactive.entries()]).toEqual([['y', 2]])
+  })
+
   it('hydrates Map in option stores', async () => {
     const useStore = defineStore('main', {
       state: () => ({ map: new Map() }),

--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -335,6 +335,29 @@ describe('State', () => {
     expect([...store.mapReactive.entries()]).toEqual([['y', 2]])
   })
 
+  it('replaces (does not union) a Set/Map nested in a reactive object on hydration', async () => {
+    const useStore = defineStore('main', () => {
+      const nested = reactive({
+        set: new Set(['default']),
+        map: new Map([['x', 1]]),
+      })
+      return { nested }
+    })
+
+    const pinia = createPinia()
+    pinia.state.value.main = {
+      nested: {
+        set: new Set(['a']),
+        map: new Map([['y', 2]]),
+      },
+    }
+    setActivePinia(pinia)
+
+    const store = useStore()
+    expect([...store.nested.set.values()]).toEqual(['a'])
+    expect([...store.nested.map.entries()]).toEqual([['y', 2]])
+  })
+
   it('hydrates Map in option stores', async () => {
     const useStore = defineStore('main', {
       state: () => ({ map: new Map() }),

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -517,7 +517,14 @@ function createSetupStore<
           if (isRef(prop)) {
             prop.value = initialState[key as keyof UnwrapRef<S>]
           } else {
-            // probably a reactive object, lets recursively assign
+            // probably a reactive object, lets recursively assign. For a
+            // reactive Set/Map the hydrated server state is authoritative, so
+            // clear any default entries first: mergeReactiveObjects otherwise
+            // unions them and leaves stale defaults behind (the isRef branch
+            // above and HMR both replace). $patch keeps its own merge semantics.
+            if (prop instanceof Set || prop instanceof Map) {
+              prop.clear()
+            }
             // @ts-expect-error: prop is unknown
             mergeReactiveObjects(prop, initialState[key])
           }

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -517,14 +517,13 @@ function createSetupStore<
           if (isRef(prop)) {
             prop.value = initialState[key as keyof UnwrapRef<S>]
           } else {
-            // probably a reactive object, lets recursively assign. For a
-            // reactive Set/Map the hydrated server state is authoritative, so
-            // clear any default entries first: mergeReactiveObjects otherwise
-            // unions them and leaves stale defaults behind (the isRef branch
-            // above and HMR both replace). $patch keeps its own merge semantics.
+            // clear keyed collections to avoid merging during hydration any
+            // default values done here rather than mergeReactiveObjects to
+            // keep `$patch` merging behavior
             if (prop instanceof Set || prop instanceof Map) {
               prop.clear()
             }
+            // probably a reactive object, lets recursively assign.
             // @ts-expect-error: prop is unknown
             mergeReactiveObjects(prop, initialState[key])
           }


### PR DESCRIPTION
Fixes #3161.

### Problem
When a setup store's state has a `reactive(new Set([...]))` / `reactive(new Map([...]))` with default entries, SSR hydration **unions** the defaults with the server state instead of **replacing** them, so entries the server removed survive (repro in #3161). The sibling `ref()` branch and HMR both replace; the server state is authoritative.

### Cause
The reactive-hydration branch calls `mergeReactiveObjects`, whose Set/Map branches add server entries onto the client collection without clearing it first.

### Fix
Clear a reactive `Set`/`Map` before merging **in the hydration path only** (`store.ts`), leaving `$patch`'s own merge semantics (which also calls `mergeReactiveObjects`) unchanged.

### Tests
Added a hydration test with **non-empty** reactive Set/Map defaults asserting the server state replaces them (the existing tests used empty defaults, so union == replace and the bug was invisible). It fails before this change and passes after; the full pinia suite stays green (211 passed), including `$patch`, and typecheck is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSR hydration for reactive `Set` and `Map` values in setup stores.
  * Hydrated `Set`/`Map` contents now fully replace existing default entries, preventing stale items from lingering after hydration.
* **Tests**
  * Added coverage to verify `Set`/`Map` hydration behavior for both top-level and nested reactive structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->