### PR TITLE
feat(nuxt): declare Nuxt 5 compatibility

### DIFF
--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -31,7 +31,7 @@ const module: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     name: 'pinia',
     configKey: 'pinia',
     compatibility: {
-      nuxt: '^3.15.0 || ^4.0.0',
+      nuxt: '^3.15.0 || ^4.0.0 || ^5.0.0',
     },
   },
   defaults: {},


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->

Closes #3165

Adds Nuxt 5 to `@pinia/nuxt`'s compatibility range without changing runtime behavior. Existing Nuxt 3 and 4 support remains unchanged.

Validation:

- `pnpm lint`
- `pnpm test` — 31 test files passed, with 260 tests passed, 3 skipped, and 3 todo
- clean Nuxt 5 consumer validation via pkg.pr.new pending preview publication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for Nuxt 5 in the `@pinia/nuxt` module.
  * Continued support for Nuxt 3.15 and Nuxt 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->