### PR TITLE
fix: guard __VUE_PROD_DEVTOOLS__ in dist output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: pnpm run test:vitest
       - run: pnpm run build
       - run: pnpm run test:dts
+      - run: pnpm run test:dist
       - run: pnpm run size
 
       - uses: codecov/codecov-action@v5

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "lint": "oxfmt --check",
     "fmt": "oxfmt",
     "lint:fix": "pnpm fmt",
-    "test": "pnpm run -r dev:prepare && pnpm run test:types && pnpm run test:vitest run && pnpm run -r test && pnpm run build && pnpm test:dts",
+    "test": "pnpm run -r dev:prepare && pnpm run test:types && pnpm run test:vitest run && pnpm run -r test && pnpm run build && pnpm test:dts && pnpm test:dist",
     "test:vitest": "vitest --coverage",
     "test:types": "tsc --build ./tsconfig.json",
     "test:dts": "pnpm run -r test:dts",
+    "test:dist": "pnpm run -r test:dist",
     "postinstall": "simple-git-hooks"
   },
   "devDependencies": {

--- a/packages/pinia/__tests__/dist-import.mjs
+++ b/packages/pinia/__tests__/dist-import.mjs
@@ -1,8 +1,8 @@
 // @ts-check
 // `dist/pinia.js` must run in plain Node, where no bundler defines
 // `__VUE_PROD_DEVTOOLS__`: unguarded, `__USE_DEVTOOLS__` throws a
-// ReferenceError inside `createPinia()` (#3167). Needs a built `dist/`, so it
-// runs after the build, as part of `test:dts`.
+// ReferenceError inside `createPinia()` (#3167). Needs a built `dist/`, so
+// `test:dist` only runs after `build`.
 
 // set before importing: with NODE_ENV=production `__DEV__` is false, so the
 // `__VUE_PROD_DEVTOOLS__` side of `__USE_DEVTOOLS__` is actually evaluated.

--- a/packages/pinia/__tests__/dist-import.mjs
+++ b/packages/pinia/__tests__/dist-import.mjs
@@ -1,18 +1,20 @@
 // @ts-check
-// Ensures the built `dist/pinia.js` works when imported directly in Node
-// without a bundler injecting compile-time defines (#3167): if
-// `__VUE_PROD_DEVTOOLS__` is left unguarded in the dist output, evaluating
-// `__USE_DEVTOOLS__` throws a ReferenceError. Requires `dist/` to be built,
-// so it runs after the build, as part of `test:dts`.
-import { spawnSync } from 'node:child_process'
-import { fileURLToPath } from 'node:url'
+// `dist/pinia.js` must run in plain Node, where no bundler defines
+// `__VUE_PROD_DEVTOOLS__`: unguarded, `__USE_DEVTOOLS__` throws a
+// ReferenceError inside `createPinia()` (#3167). Needs a built `dist/`, so it
+// runs after the build, as part of `test:dts`.
 
-const script = `
-import { createApp } from 'vue'
-import { createPinia, defineStore } from './dist/pinia.js'
+// set before importing: with NODE_ENV=production `__DEV__` is false, so the
+// `__VUE_PROD_DEVTOOLS__` side of `__USE_DEVTOOLS__` is actually evaluated.
+// static imports are hoisted, hence the dynamic ones below
+process.env.NODE_ENV = 'production'
+
+const { createApp } = await import('vue')
+const { createPinia, defineStore } = await import('../dist/pinia.js')
 
 const pinia = createPinia()
 createApp({}).use(pinia)
+
 const useCounterStore = defineStore('counter', {
   state: () => ({ n: 0 }),
   actions: {
@@ -21,33 +23,9 @@ const useCounterStore = defineStore('counter', {
     },
   },
 })
+
 const counter = useCounterStore(pinia)
 counter.increment()
 if (counter.n !== 1) {
-  throw new Error(\`expected counter.n to be 1, got \${counter.n}\`)
-}
-`
-
-// with NODE_ENV=production, __DEV__ is false at runtime, so the
-// __VUE_PROD_DEVTOOLS__ side of the __USE_DEVTOOLS__ define is evaluated
-for (const NODE_ENV of ['production', undefined]) {
-  const env = { ...process.env }
-  delete env.NODE_ENV
-  if (NODE_ENV) env.NODE_ENV = NODE_ENV
-  const { status, stderr } = spawnSync(
-    process.execPath,
-    ['--input-type=module', '-e', script],
-    {
-      cwd: fileURLToPath(new URL('..', import.meta.url)),
-      env,
-      encoding: 'utf-8',
-    }
-  )
-  if (status !== 0) {
-    console.error(stderr)
-    console.error(
-      `Importing dist/pinia.js in Node (NODE_ENV=${NODE_ENV}) failed`
-    )
-    process.exit(1)
-  }
+  throw new Error(`expected counter.n to be 1, got ${counter.n}`)
 }

--- a/packages/pinia/__tests__/dist-import.mjs
+++ b/packages/pinia/__tests__/dist-import.mjs
@@ -1,0 +1,53 @@
+// @ts-check
+// Ensures the built `dist/pinia.js` works when imported directly in Node
+// without a bundler injecting compile-time defines (#3167): if
+// `__VUE_PROD_DEVTOOLS__` is left unguarded in the dist output, evaluating
+// `__USE_DEVTOOLS__` throws a ReferenceError. Requires `dist/` to be built,
+// so it runs after the build, as part of `test:dts`.
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const script = `
+import { createApp } from 'vue'
+import { createPinia, defineStore } from './dist/pinia.js'
+
+const pinia = createPinia()
+createApp({}).use(pinia)
+const useCounterStore = defineStore('counter', {
+  state: () => ({ n: 0 }),
+  actions: {
+    increment() {
+      this.n++
+    },
+  },
+})
+const counter = useCounterStore(pinia)
+counter.increment()
+if (counter.n !== 1) {
+  throw new Error(\`expected counter.n to be 1, got \${counter.n}\`)
+}
+`
+
+// with NODE_ENV=production, __DEV__ is false at runtime, so the
+// __VUE_PROD_DEVTOOLS__ side of the __USE_DEVTOOLS__ define is evaluated
+for (const NODE_ENV of ['production', undefined]) {
+  const env = { ...process.env }
+  delete env.NODE_ENV
+  if (NODE_ENV) env.NODE_ENV = NODE_ENV
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', script],
+    {
+      cwd: fileURLToPath(new URL('..', import.meta.url)),
+      env,
+      encoding: 'utf-8',
+    }
+  )
+  if (status !== 0) {
+    console.error(stderr)
+    console.error(
+      `Importing dist/pinia.js in Node (NODE_ENV=${NODE_ENV}) failed`
+    )
+    process.exit(1)
+  }
+}

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -51,7 +51,8 @@
   "scripts": {
     "build": "tsdown",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l pinia -r 1",
-    "test:dts": "tsc -p ./test-dts/tsconfig.json",
+    "test:dist": "node ./__tests__/dist-import.mjs",
+    "test:dts": "tsc -p ./test-dts/tsconfig.json && pnpm run test:dist",
     "test": "pnpm run build && pnpm test:dts"
   },
   "dependencies": {

--- a/packages/pinia/package.json
+++ b/packages/pinia/package.json
@@ -52,8 +52,8 @@
     "build": "tsdown",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l pinia -r 1",
     "test:dist": "node ./__tests__/dist-import.mjs",
-    "test:dts": "tsc -p ./test-dts/tsconfig.json && pnpm run test:dist",
-    "test": "pnpm run build && pnpm test:dts"
+    "test:dts": "tsc -p ./test-dts/tsconfig.json",
+    "test": "pnpm run build && pnpm test:dts && pnpm test:dist"
   },
   "dependencies": {
     "nostics": "^1.1.4"

--- a/packages/pinia/tsdown.config.ts
+++ b/packages/pinia/tsdown.config.ts
@@ -20,8 +20,10 @@ const commonOptions = defineConfig({
   define: {
     __DEV__,
     __TEST__,
-    // __VUE_PROD_DEVTOOLS__ is replaced by the vite vue plugin
-    __USE_DEVTOOLS__: `((${__DEV__} || __VUE_PROD_DEVTOOLS__) && !${__TEST__})`,
+    // __VUE_PROD_DEVTOOLS__ is replaced by the vite vue plugin but must be
+    // guarded so the dist files also work without a bundler define, e.g. when
+    // imported directly in Node (#3167)
+    __USE_DEVTOOLS__: `((${__DEV__} || (typeof __VUE_PROD_DEVTOOLS__ !== 'undefined' && __VUE_PROD_DEVTOOLS__)) && !${__TEST__})`,
   },
   dts: false,
   fixedExtension: false,


### PR DESCRIPTION
close #3167

**What was broken**

Since the tsdown build migration (898b7c9, #3092), the `__USE_DEVTOOLS__` define inlines `__VUE_PROD_DEVTOOLS__` as a bare global into `dist/pinia.js`:

```js
if ((process.env.NODE_ENV !== "production" || __VUE_PROD_DEVTOOLS__) && ...
```

The v3 rollup build emitted a guarded form instead: `typeof __VUE_PROD_DEVTOOLS__ !== 'undefined' && __VUE_PROD_DEVTOOLS__`. Without the guard, evaluating the dist file anywhere a bundler hasn't defined the global throws `ReferenceError: __VUE_PROD_DEVTOOLS__ is not defined` inside `createPinia()`.

That is what #3167 actually hits: Nitro's prerenderer externalizes `node_modules`, so its chunks import `dist/pinia.js` directly in Node. `createPinia()` throws, the `@pinia/nuxt` plugin `setup()` fails, `$pinia` is never provided, and the visible symptom becomes the misleading `Cannot read properties of undefined (reading 'state')` from the `app:rendered` hook. The same ReferenceError reproduces without Nuxt in any plain-Node consumption of the dist file (SSR with externalized deps, node test setups without the vite plugin's defines).

**Reproduction**

Bare Node, pinia 4.0.2:

```
NODE_ENV=production node --input-type=module \
  -e "const { createPinia } = await import('pinia'); createPinia()"
```

throws the ReferenceError; with this branch it runs. Also verified end to end with a minimal Nuxt 4.5 + @pinia/nuxt 1.0.1 app with one prerendered route (matching the issue's reproduction): `nuxt build` fails on 4.0.2 and succeeds with a pack of this branch, with `@pinia/nuxt` unchanged. The same app on pinia 3 / @pinia/nuxt 0.11 builds fine, which brackets the regression.

**The change**

One line in `packages/pinia/tsdown.config.ts`: restore the typeof guard inside the `__USE_DEVTOOLS__` define, so the dist output degrades to `false` when the global is not defined. Bundlers that do define `__VUE_PROD_DEVTOOLS__` constant-fold the expression exactly as before.

Alternatives considered: guarding each call site in `src` (more invasive, same emitted result), or changing `@pinia/nuxt` to not rely on injections in `app:rendered` (does not fix the underlying ReferenceError, which reproduces without Nuxt).

**Testing**

Full local suite is green (lint, types, vitest, builds, dts). There is no in-repo test that exercises built dist output, so per the CONTRIBUTING note about hard-to-test changes: I am happy to add a small post-build smoke script (import `dist/pinia.js` in Node with `NODE_ENV=production` and call `createPinia()`) if you want one — tell me where you would like it wired.

Disclosure: this change was investigated and prepared with AI assistance (Claude Code). I reviewed it and can explain every line.



## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for direct Node.js imports and environments without bundler-defined production flags.
  - Preserved existing development and test-mode behavior for devtools availability.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct Node.js imports of the production build when bundler configuration is unavailable.
  * Preserved existing development and test-mode behavior.

* **Tests**
  * Added coverage for importing the production build directly and verifying store actions work correctly.
  * Added distribution tests to local and continuous integration test runs.

* **Chores**
  * Updated test commands to include distribution import validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->