### PR TITLE
chore(docs): add robots.txt and sitemap.xml

### DIFF
--- a/packages/docs/.vitepress/config/shared.ts
+++ b/packages/docs/.vitepress/config/shared.ts
@@ -35,6 +35,10 @@ export const sharedConfig = defineConfig({
   title: 'Pinia',
   appearance: 'dark',
 
+  sitemap: {
+    hostname: 'https://pinia.vuejs.org',
+  },
+
   markdown: {
     theme: {
       dark: 'dracula-soft',

--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Content-Signal: search=yes, ai-train=yes, ai-input=yes
+Disallow:
+
+Sitemap: https://pinia.vuejs.org/sitemap.xml 


### PR DESCRIPTION
<!--
Please make sure to include a test! If this is closing an
existing issue, reference that issue as well.
-->
## Description of Problem
Fixes: #3170 
https://pinia.vuejs.org/robots.txt  and https://pinia.vuejs.org/sitemap.xml are 404ing 
<img width="1470" height="589" alt="image" src="https://github.com/user-attachments/assets/821935e5-4e67-47e5-bec5-aafa0bff8444" />



## Proposed Solution
- Update packages/docs/.vitepress/config/shared.ts to include a sitemap following [Vue docs pattern](https://github.com/vuejs/docs/blob/33ff72af9008c68e05360de34ef3e96e74bf70c9/.vitepress/config.ts#L585-L588)
- Add a robots.txt file to the public folder. 

## Testing
- Tested by building and previewing locally. 


## Additional Information
- This robots.txt file is based on [Nuxt's robots.txt](https://nuxt.com/robots.txt)
- Pinia docs use Vitpress 1.6.4, whereas Vue docs use ^2.0.0-alpha.17. Somewhere in the differences between these versions, the sitemaps.xml header has been updated from text/xml to application/xml; as a result, browsers render sitemaps as "text" vs as XML. This has no SEO impact, but if the Pina team would like me to do a Vitepress upgrade pr l can.



 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sitemap configuration for the documentation site.
  * Added crawler guidance and a sitemap reference to improve documentation discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->