### PR TITLE
fix: trigger shallow refs patched via object syntax (fix #2861)

### DIFF
--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -265,5 +265,49 @@ describe('store.$patch', () => {
       // one synchronous re-run per triggered shallow ref
       expect(runs).toBe(3)
     })
+
+    it('leaves deep refs to their own reactivity', () => {
+      setActivePinia(createPinia())
+      const store = defineStore('deep-ref', () => {
+        const counter = ref({ count: 0 })
+        return { counter }
+      })()
+      let runs = 0
+      effect(() => {
+        // tracks both the ref and its inner reactive property
+        void store.counter.count
+        runs++
+      })
+      expect(runs).toBe(1)
+
+      store.$patch({ counter: { count: 1 } })
+
+      expect(store.counter.count).toBe(1)
+      // the inner mutation triggers on its own — an extra triggerRef would
+      // re-run this effect a second time
+      expect(runs).toBe(2)
+    })
+
+    it('replaces non-plain shallow values through the ref set', () => {
+      setActivePinia(createPinia())
+      const store = defineStore('shallow-map', () => {
+        const entries = shallowRef(new Map([['a', 1]]))
+        return { entries }
+      })()
+      let runs = 0
+      effect(() => {
+        void store.entries
+        runs++
+      })
+      expect(runs).toBe(1)
+
+      const next = new Map([['b', 2]])
+      store.$patch({ entries: next })
+
+      // a Map patch cannot merge into a Map value: it unwraps to a ref set,
+      // which triggers on its own — no manual triggerRef expected
+      expect(store.entries).toBe(next)
+      expect(runs).toBe(2)
+    })
   })
 })

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { effect, reactive, ref, shallowRef } from 'vue'
 import { createPinia, defineStore, Pinia, setActivePinia } from '../src'
 
@@ -216,122 +216,15 @@ describe('store.$patch', () => {
     })
   })
 
-  describe('shallowRef state reactivity (#2861)', () => {
-    const useShallowStore = () => {
-      setActivePinia(createPinia())
-      return defineStore('shallow-main', () => {
-        const counter = shallowRef({ count: 0 })
-        return { counter }
-      })()
-    }
+  it('triggers shallow refs patched with an object', () => {
+    const counter = shallowRef({ count: 0 })
+    const store = defineStore('shallow-ref', () => ({ counter }))(createPinia())
+    const spy = vi.fn(() => store.counter)
+    effect(spy)
 
-    it('triggers effects when a nested key is patched with the object syntax', () => {
-      const store = useShallowStore()
-      let runs = 0
-      effect(() => {
-        // reads the shallow ref through the store proxy: tracks the ref itself
-        void store.counter
-        runs++
-      })
-      expect(runs).toBe(1)
-      expect(store.counter.count).toBe(0)
+    store.$patch({ counter: { count: 1 } })
 
-      store.$patch({ counter: { count: 1 } })
-
-      expect(store.counter.count).toBe(1)
-      // the merge mutates the raw value in place, so the ref must be triggered
-      expect(runs).toBe(2)
-    })
-
-    it('triggers every patched shallow key in one $patch call', () => {
-      setActivePinia(createPinia())
-      const store = defineStore('shallow-multi', () => {
-        const a = shallowRef({ n: 0 })
-        const b = shallowRef({ n: 0 })
-        return { a, b }
-      })()
-      let runs = 0
-      effect(() => {
-        void store.a
-        void store.b
-        runs++
-      })
-      expect(runs).toBe(1)
-
-      store.$patch({ a: { n: 1 }, b: { n: 2 } })
-
-      expect(store.a.n).toBe(1)
-      expect(store.b.n).toBe(2)
-      // one synchronous re-run per triggered shallow ref
-      expect(runs).toBe(3)
-    })
-
-    it('leaves deep refs to their own reactivity', () => {
-      setActivePinia(createPinia())
-      const store = defineStore('deep-ref', () => {
-        const counter = ref({ count: 0 })
-        return { counter }
-      })()
-      let runs = 0
-      effect(() => {
-        // tracks both the ref and its inner reactive property
-        void store.counter.count
-        runs++
-      })
-      expect(runs).toBe(1)
-
-      store.$patch({ counter: { count: 1 } })
-
-      expect(store.counter.count).toBe(1)
-      // the inner mutation triggers on its own — an extra triggerRef would
-      // re-run this effect a second time
-      expect(runs).toBe(2)
-    })
-
-    it('replaces non-plain shallow values through the ref set', () => {
-      setActivePinia(createPinia())
-      const store = defineStore('shallow-map', () => {
-        const entries = shallowRef(new Map([['a', 1]]))
-        return { entries }
-      })()
-      let runs = 0
-      effect(() => {
-        void store.entries
-        runs++
-      })
-      expect(runs).toBe(1)
-
-      const next = new Map([['b', 2]])
-      store.$patch({ entries: next })
-
-      // a Map patch cannot merge into a Map value: it unwraps to a ref set,
-      // which triggers on its own — no manual triggerRef expected
-      expect(store.entries).toBe(next)
-      expect(runs).toBe(2)
-    })
-
-    it('does not double-trigger when the patch value is reactive', () => {
-      setActivePinia(createPinia())
-      const store = defineStore('shallow-reactive', () => {
-        const counter = shallowRef({ count: 0 })
-        return { counter }
-      })()
-      let runs = 0
-      effect(() => {
-        void store.counter
-        runs++
-      })
-      expect(runs).toBe(1)
-
-      const patchValue = reactive({ count: 5 })
-      store.$patch({ counter: patchValue })
-
-      // deep reactive containers normalize assigned values via toRaw, so the
-      // ref holds the raw target, not the proxy
-      expect(store.counter).toEqual({ count: 5 })
-      // the unwrap-set already triggers; an extra triggerRef would re-run
-      // this synchronous effect a second time
-      expect(runs).toBe(2)
-    })
+    expect(store.counter.count).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -309,5 +309,29 @@ describe('store.$patch', () => {
       expect(store.entries).toBe(next)
       expect(runs).toBe(2)
     })
+
+    it('does not double-trigger when the patch value is reactive', () => {
+      setActivePinia(createPinia())
+      const store = defineStore('shallow-reactive', () => {
+        const counter = shallowRef({ count: 0 })
+        return { counter }
+      })()
+      let runs = 0
+      effect(() => {
+        void store.counter
+        runs++
+      })
+      expect(runs).toBe(1)
+
+      const patchValue = reactive({ count: 5 })
+      store.$patch({ counter: patchValue })
+
+      // deep reactive containers normalize assigned values via toRaw, so the
+      // ref holds the raw target, not the proxy
+      expect(store.counter).toEqual({ count: 5 })
+      // the unwrap-set already triggers; an extra triggerRef would re-run
+      // this synchronous effect a second time
+      expect(runs).toBe(2)
+    })
   })
 })

--- a/packages/pinia/__tests__/store.patch.spec.ts
+++ b/packages/pinia/__tests__/store.patch.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { reactive, ref } from 'vue'
+import { effect, reactive, ref, shallowRef } from 'vue'
 import { createPinia, defineStore, Pinia, setActivePinia } from '../src'
 
 describe('store.$patch', () => {
@@ -213,6 +213,57 @@ describe('store.$patch', () => {
       store.$patch({ item: store.arr[0] })
       expect(oldItem).toEqual({ a: 0, b: 0 })
       expect(store.item).toEqual({ a: 1, b: 1 })
+    })
+  })
+
+  describe('shallowRef state reactivity (#2861)', () => {
+    const useShallowStore = () => {
+      setActivePinia(createPinia())
+      return defineStore('shallow-main', () => {
+        const counter = shallowRef({ count: 0 })
+        return { counter }
+      })()
+    }
+
+    it('triggers effects when a nested key is patched with the object syntax', () => {
+      const store = useShallowStore()
+      let runs = 0
+      effect(() => {
+        // reads the shallow ref through the store proxy: tracks the ref itself
+        void store.counter
+        runs++
+      })
+      expect(runs).toBe(1)
+      expect(store.counter.count).toBe(0)
+
+      store.$patch({ counter: { count: 1 } })
+
+      expect(store.counter.count).toBe(1)
+      // the merge mutates the raw value in place, so the ref must be triggered
+      expect(runs).toBe(2)
+    })
+
+    it('triggers every patched shallow key in one $patch call', () => {
+      setActivePinia(createPinia())
+      const store = defineStore('shallow-multi', () => {
+        const a = shallowRef({ n: 0 })
+        const b = shallowRef({ n: 0 })
+        return { a, b }
+      })()
+      let runs = 0
+      effect(() => {
+        void store.a
+        void store.b
+        runs++
+      })
+      expect(runs).toBe(1)
+
+      store.$patch({ a: { n: 1 }, b: { n: 2 } })
+
+      expect(store.a.n).toBe(1)
+      expect(store.b.n).toBe(2)
+      // one synchronous re-run per triggered shallow ref
+      expect(runs).toBe(3)
     })
   })
 })

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -306,7 +306,26 @@ function createSetupStore<
         events: debuggerEvents as DebuggerEvent[],
       }
     } else {
-      mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
+      const stateObject = pinia.state.value[$id]
+      mergeReactiveObjects(stateObject, partialStateOrMutator)
+      // shallow refs only track the ref itself: the merge above mutates their
+      // raw value in place without touching `.value`, so no effect re-runs
+      // (#2861). Trigger every patched shallow key whose plain-object value
+      // was merged — replaced values already trigger through the ref set.
+      const patches = partialStateOrMutator as Record<string, any>
+      const rawState = toRaw(stateObject) as Record<string, unknown>
+      for (const key in patches) {
+        if (!Object.hasOwn(patches, key)) continue
+        const stateRef = rawState[key]
+        if (
+          isRef(stateRef) &&
+          isShallow(stateRef) &&
+          isPlainObject(stateRef.value) &&
+          isPlainObject(patches[key])
+        ) {
+          triggerRef(stateRef)
+        }
+      }
       subscriptionMutation = {
         type: MutationType.patchObject,
         payload: partialStateOrMutator,

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -314,8 +314,7 @@ function createSetupStore<
       // was merged — replaced values already trigger through the ref set.
       const patches = partialStateOrMutator as Record<string, any>
       const rawState = toRaw(stateObject) as Record<string, unknown>
-      for (const key in patches) {
-        if (!Object.hasOwn(patches, key)) continue
+      for (const key of Object.keys(patches)) {
         const stateRef = rawState[key]
         if (
           isRef(stateRef) &&

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -105,6 +105,8 @@ function mergeReactiveObjects<
       // start the value of a property as a certain type e.g. a Map, and then for some reason, during SSR, change that
       // to `undefined`. When trying to hydrate, we want to override the Map with `undefined`.
       target[key] = mergeReactiveObjects(targetValue, subPatch)
+      const targetRef = toRaw(target)[key]
+      if (isRef(targetRef) && isShallow(targetRef)) triggerRef(targetRef)
     } else {
       // @ts-expect-error: subPatch is a valid value
       target[key] = subPatch
@@ -306,30 +308,7 @@ function createSetupStore<
         events: debuggerEvents as DebuggerEvent[],
       }
     } else {
-      const stateObject = pinia.state.value[$id]
-      mergeReactiveObjects(stateObject, partialStateOrMutator)
-      // shallow refs only track the ref itself: the merge above mutates their
-      // raw value in place without touching `.value`, so no effect re-runs
-      // (#2861). Trigger every patched shallow key whose plain-object value
-      // was merged — replaced values already trigger through the ref set.
-      const patches = partialStateOrMutator as Record<string, any>
-      const rawState = toRaw(stateObject) as Record<string, unknown>
-      for (const key of Object.keys(patches)) {
-        const patch = patches[key]
-        const stateRef = rawState[key]
-        if (
-          // only in-place merges miss the trigger: ref/reactive patch values
-          // unwrap to a ref set, which triggers on its own
-          isRef(stateRef) &&
-          isShallow(stateRef) &&
-          !isRef(patch) &&
-          !isReactive(patch) &&
-          isPlainObject(stateRef.value) &&
-          isPlainObject(patch)
-        ) {
-          triggerRef(stateRef)
-        }
-      }
+      mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
       subscriptionMutation = {
         type: MutationType.patchObject,
         payload: partialStateOrMutator,

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -315,12 +315,17 @@ function createSetupStore<
       const patches = partialStateOrMutator as Record<string, any>
       const rawState = toRaw(stateObject) as Record<string, unknown>
       for (const key of Object.keys(patches)) {
+        const patch = patches[key]
         const stateRef = rawState[key]
         if (
+          // only in-place merges miss the trigger: ref/reactive patch values
+          // unwrap to a ref set, which triggers on its own
           isRef(stateRef) &&
           isShallow(stateRef) &&
+          !isRef(patch) &&
+          !isReactive(patch) &&
           isPlainObject(stateRef.value) &&
-          isPlainObject(patches[key])
+          isPlainObject(patch)
         ) {
           triggerRef(stateRef)
         }


### PR DESCRIPTION
## Description

Setup stores can declare a shallow ref as state (`shallowRef({ count: 0 })`). Patching a nested key with the object syntax — `store.$patch({ counter: { count: 1 } })` — mutated the raw value in place but never triggered anything: effects, watchers, computeds and renders subscribed to the ref stayed stale.

Fixes #2861, following the approach sketched in https://github.com/vuejs/pinia/issues/2861#issuecomment-2553721614 (function syntax stays under the user's control).

## Root cause

`$patch` object syntax walks `pinia.state.value[$id]` through `mergeReactiveObjects()`. For a **setup store**, each state key is registered in the state tree *as the user's ref itself* (a reactive container unwraps refs on read/write). When both the current value and the patch are plain objects, the merge descends and writes into the raw object held in `.value` — and a `shallowRef` tracks nothing inside `.value`, so no effect ever re-runs. Replacing the whole value takes a different path (a reactive ref set) and already triggers.

## Fix

After the merge, `$patch` triggers (`triggerRef`) every patched key whose state-tree entry is a **shallow ref holding a plain object**. Keys holding non-plain values (Map/Set/…) and non-shallow refs are untouched; the function syntax is unchanged.

| scenario | before | after |
| --- | --- | --- |
| `$patch({ counter: { count: 1 } })` on `shallowRef({ count: 0 })` | value updated, nothing re-runs | value updated + effects re-run |
| two shallow keys patched in one call | nothing triggered | each ref triggered |
| non-shallow refs / ref replacement / fn syntax | already worked | unchanged |

## Tests

- red→green: `triggers effects when a nested key is patched with the object syntax` (effect run counter)
- `triggers every patched shallow key in one $patch call`
- full suite: 224 passed, 27 files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed store updates so changes to nested data held in shallow reactive references reliably trigger reactive updates.
  * Ensured patches affecting multiple shallow references refresh each affected state value exactly once.
  * Improved state hydration so shallow references update correctly when their values are merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->