### PR TITLE
fix: keep notifying subscriptions when $patch throws

### DIFF
--- a/packages/pinia/__tests__/subscriptions.spec.ts
+++ b/packages/pinia/__tests__/subscriptions.spec.ts
@@ -181,6 +181,27 @@ describe('Subscriptions', () => {
       expect(spySync).toHaveBeenCalledTimes(2)
     })
 
+    it('keeps notifying subscribers if $patch throws', async () => {
+      const store = useStore()
+      const spySync = vi.fn()
+      const spy = vi.fn()
+      store.$subscribe(spySync, { flush: 'sync' })
+      store.$subscribe(spy)
+
+      expect(() =>
+        store.$patch((state): void => {
+          state.user = 'Ana'
+          throw new Error('failed patch')
+        })
+      ).toThrow('failed patch')
+
+      await nextTick()
+      store.user = 'Cleiton'
+      expect(spySync).toHaveBeenCalledTimes(1)
+      await nextTick()
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
     it('unsubscribes callback when unsubscribe is called', () => {
       const spy = vi.fn()
       const store = useStore()

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -300,29 +300,34 @@ function createSetupStore<
     if (__DEV__) {
       debuggerEvents = []
     }
-    if (typeof partialStateOrMutator === 'function') {
-      partialStateOrMutator(pinia.state.value[$id] as UnwrapRef<S>)
-      subscriptionMutation = {
-        type: MutationType.patchFunction,
-        storeId: $id,
-        events: debuggerEvents as DebuggerEvent[],
+    try {
+      if (typeof partialStateOrMutator === 'function') {
+        partialStateOrMutator(pinia.state.value[$id] as UnwrapRef<S>)
+        subscriptionMutation = {
+          type: MutationType.patchFunction,
+          storeId: $id,
+          events: debuggerEvents as DebuggerEvent[],
+        }
+      } else {
+        mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
+        subscriptionMutation = {
+          type: MutationType.patchObject,
+          payload: partialStateOrMutator,
+          storeId: $id,
+          events: debuggerEvents as DebuggerEvent[],
+        }
       }
-    } else {
-      mergeReactiveObjects(pinia.state.value[$id], partialStateOrMutator)
-      subscriptionMutation = {
-        type: MutationType.patchObject,
-        payload: partialStateOrMutator,
-        storeId: $id,
-        events: debuggerEvents as DebuggerEvent[],
-      }
+    } finally {
+      // resume even if the mutation threw, otherwise the store stops notifying
+      // its subscriptions for good
+      const myListenerId = (activeListener = Symbol())
+      nextTick().then(() => {
+        if (activeListener === myListenerId) {
+          isListening = true
+        }
+      })
+      isSyncListening = true
     }
-    const myListenerId = (activeListener = Symbol())
-    nextTick().then(() => {
-      if (activeListener === myListenerId) {
-        isListening = true
-      }
-    })
-    isSyncListening = true
     // because we paused the watcher, we need to manually call the subscriptions
     triggerSubscriptions(
       subscriptions,


### PR DESCRIPTION
`$patch()` sets `isListening` and `isSyncListening` to `false`, applies the mutation, then sets them back. The restore is not protected against the mutation throwing, so if the mutator (or the object merge) throws, the flags stay `false` and every `$subscribe()` callback of that store silently stops firing on direct mutations. It only recovers if a later `$patch()` happens to succeed.

`packages/pinia/src/store.ts`, `$patch()`: the assignments after the `if/else` are skipped when the mutation throws.

### Reproduction

```ts
const store = useStore()
store.$subscribe(spy, { flush: 'sync' })

try {
  store.$patch((state) => {
    state.user = 'Ana'
    throw new Error('failed patch')
  })
} catch {}

store.user = 'Cleiton'
// spy was never called, and never will be
```

### Fix

Move the restore into a `finally` block. The error still propagates and `triggerSubscriptions()` is still skipped for the failed patch, so nothing is reported for a mutation that did not complete, but the store keeps notifying afterwards.

### Test

Added to the existing `Options Stores` / `Setup Stores` matrix in `subscriptions.spec.ts`, covering both store flavours and both the `sync` and the default flush. It fails on `v4` and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where store subscriptions could stop responding after a state patch operation threw an error.
  * Subscriptions now continue receiving notifications after failed patch callbacks or state merges.
  * Patch errors continue to be reported while subscription behavior remains consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->