### PR TITLE
fix: replace reactive arrays on hydration instead of merging into them

### DIFF
--- a/packages/pinia/__tests__/state.spec.ts
+++ b/packages/pinia/__tests__/state.spec.ts
@@ -335,6 +335,26 @@ describe('State', () => {
     expect([...store.mapReactive.entries()]).toEqual([['y', 2]])
   })
 
+  it('truncates a reactive Array on hydration', async () => {
+    const useStore = defineStore('main', () => {
+      const listReactive = reactive(['a', 'b', 'c'])
+      const listRef = ref(['a', 'b', 'c'])
+      return { listReactive, listRef }
+    })
+
+    const pinia = createPinia()
+    pinia.state.value.main = {
+      listReactive: ['x'],
+      listRef: ['x'],
+    }
+    setActivePinia(pinia)
+
+    const store = useStore()
+    // The server state is authoritative, so the default entries are gone.
+    expect([...store.listReactive]).toEqual(['x'])
+    expect([...store.listRef]).toEqual(['x'])
+  })
+
   it('replaces (does not union) a Set/Map nested in a reactive object on hydration', async () => {
     const useStore = defineStore('main', () => {
       const nested = reactive({

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -527,6 +527,8 @@ function createSetupStore<
             // keep `$patch` merging behavior
             if (prop instanceof Set || prop instanceof Map) {
               prop.clear()
+            } else if (Array.isArray(prop)) {
+              prop.length = 0
             }
             // probably a reactive object, lets recursively assign.
             // @ts-expect-error: prop is unknown


### PR DESCRIPTION
With a setup store whose state has a reactive array, hydration leaves stale default items behind when the incoming state is shorter:

```js
// store: () => ({ list: reactive(['a', 'b', 'c']) })
// hydrated with { list: ['x'] }
store.list // ['x', 'b', 'c'], expected ['x']
```

On hydration the code clears `Set`/`Map` before merging so the server value wins, but a reactive array isn't a `Set`/`Map`, so `mergeReactiveObjects` just assigns by index and never shortens it. A `ref([...])` array is fine because it's replaced wholesale.

I added an `Array.isArray(prop)` case next to the Set/Map clear that resets the length before the merge, so the array is replaced the same way. Added a test (with a `ref` control that already passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state hydration so server-provided array values replace default array contents instead of being appended.
  * Ensured reactive arrays and array references are cleared before hydrated state is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->