### PR TITLE
fix: include plugin-added reactive() state in storeToRefs

### DIFF
--- a/packages/pinia/__tests__/storeToRefs.spec.ts
+++ b/packages/pinia/__tests__/storeToRefs.spec.ts
@@ -153,6 +153,28 @@ describe('storeToRefs', () => {
     ).toEqual(objectOfRefs({ n: 0, pluginN: 20 }))
   })
 
+  it('contain plugin reactive() states', () => {
+    const pinia = createPinia()
+    // directly push because no app
+    pinia._p.push(() => ({
+      // @ts-expect-error: cannot set a ref yet
+      pluginN: ref(20),
+      reactiveN: reactive({ x: 1 }),
+    }))
+    setActivePinia(pinia)
+
+    const store = defineStore('a', {
+      state: () => ({ n: 0 }),
+    })()
+
+    const refs = storeToRefs(store)
+    expect(refs).toHaveProperty('reactiveN')
+    // mutating the store flows through the extracted ref
+    // @ts-expect-error: added by plugin
+    store.reactiveN.x = 2
+    expect(refs.reactiveN.value).toEqual({ x: 2 })
+  })
+
   it('preserve setters in getters', () => {
     const useStore = defineStore('main', () => {
       const n = ref(0)

--- a/packages/pinia/src/store.ts
+++ b/packages/pinia/src/store.ts
@@ -788,6 +788,9 @@ function createSetupStore<
     }
 
     assign(store, extensions)
+    // allows retrieving reactive objects with `storeToRefs()`. Must be called
+    // after assigning to the reactive object.
+    assign(toRaw(store), extensions)
   })
 
   if (


### PR DESCRIPTION
If a plugin adds a `reactive()` object to the store, `storeToRefs()` silently drops it:

```js
pinia.use(() => ({ shared: reactive({ x: 1 }) }))
storeToRefs(store) // no `shared`
```

Plugin extensions are applied with `assign(store, extensions)`, which writes through the reactive proxy, so the raw target ends up with the unwrapped (plain) value. `storeToRefs` iterates `toRaw(store)` and skips anything that isn't reactive, so the plugin's reactive state doesn't make it. Setup-store state avoids this because `createSetupStore` also assigns onto `toRaw(store)`; plugin extensions never got that.

I added the same `assign(toRaw(store), extensions)` right after the existing assign, so the reactive proxy is present on the raw target. A `ref` from a plugin already worked; this makes `reactive()` behave the same. Added a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin-provided reactive objects are now correctly exposed by `storeToRefs()`.
  * Updates to reactive objects added by plugins are reflected through their extracted refs.

* **Tests**
  * Added coverage verifying reactive plugin state behavior with `storeToRefs()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->