### PR TITLE
fix(devtools): register the devtools plugin once, with settings

### DIFF
--- a/packages/pinia/__tests__/devtools-api-stub.ts
+++ b/packages/pinia/__tests__/devtools-api-stub.ts
@@ -40,6 +40,21 @@ export function connectDevtoolsClient(api: any): void {
   registrations.forEach((r) => r.setupFn(api))
 }
 
+/**
+ * Same as `connectDevtoolsClient`, but gives each registration its own API
+ * (built by `makeApi`), so tests can assert which registration a store's
+ * events flow through.
+ */
+export function connectDevtoolsClientPerRegistration(
+  makeApi: () => any
+): any[] {
+  return registrations.map((r) => {
+    const api = makeApi()
+    r.setupFn(api)
+    return api
+  })
+}
+
 export function createFakeDevtoolsApi() {
   return {
     now: () => 123,

--- a/packages/pinia/__tests__/devtools-api-stub.ts
+++ b/packages/pinia/__tests__/devtools-api-stub.ts
@@ -1,0 +1,61 @@
+import { vi } from 'vitest'
+
+/**
+ * Test stub for `@vue/devtools-api`, aliased in the root vitest.config.ts.
+ *
+ * The real module queues plugins until a devtools client connects, which never
+ * happens in tests, making the registration lifecycle unobservable. No other
+ * test executes devtools code (`__USE_DEVTOOLS__` is `false` in tests), so
+ * replacing the module here is safe. `pinia` only imports
+ * `setupDevtoolsPlugin` from it.
+ */
+
+export interface DevtoolsApiRegistration {
+  descriptor: any
+  setupFn: (api: any) => void
+}
+
+let registrations: DevtoolsApiRegistration[] = []
+
+export function setupDevtoolsPlugin(
+  descriptor: any,
+  setupFn: (api: any) => void
+): void {
+  registrations.push({ descriptor, setupFn })
+}
+
+export function getDevtoolsRegistrations(): DevtoolsApiRegistration[] {
+  return registrations
+}
+
+export function resetDevtoolsRegistrations(): void {
+  registrations = []
+}
+
+/**
+ * Simulates the devtools client connecting: runs every queued setup callback
+ * with the given (fake) API.
+ */
+export function connectDevtoolsClient(api: any): void {
+  registrations.forEach((r) => r.setupFn(api))
+}
+
+export function createFakeDevtoolsApi() {
+  return {
+    now: () => 123,
+    addTimelineLayer: vi.fn(),
+    addInspector: vi.fn(),
+    addTimelineEvent: vi.fn(),
+    sendInspectorTree: vi.fn(),
+    sendInspectorState: vi.fn(),
+    notifyComponentUpdate: vi.fn(),
+    getSettings: vi.fn(() => ({ logStoreChanges: true })),
+    on: {
+      inspectComponent: vi.fn(),
+      getInspectorTree: vi.fn(),
+      getInspectorState: vi.fn(),
+      editInspectorState: vi.fn(),
+      editComponentState: vi.fn(),
+    },
+  }
+}

--- a/packages/pinia/__tests__/devtools-registration.spec.ts
+++ b/packages/pinia/__tests__/devtools-registration.spec.ts
@@ -4,6 +4,7 @@ import { createPinia, defineStore } from '../src'
 import { devtoolsPlugin, registerPiniaDevtools } from '../src/devtools'
 import {
   connectDevtoolsClient,
+  connectDevtoolsClientPerRegistration,
   createFakeDevtoolsApi,
   getDevtoolsRegistrations,
   resetDevtoolsRegistrations,
@@ -96,5 +97,39 @@ describe('devtools registration', () => {
       })
     )
     expect(api.sendInspectorState).toHaveBeenCalledWith('pinia')
+  })
+
+  it('registers one plugin per Pinia instance, even on the same application', async () => {
+    const { app, pinia } = setupApp()
+
+    // install-time registrations (the compile-time devtools flag is off in
+    // tests, so registerPiniaDevtools is called directly, as install would)
+    registerPiniaDevtools(app, pinia)
+
+    // a second Pinia instance installed on the same application
+    const pinia2 = createPinia()
+    pinia2.use(devtoolsPlugin)
+    app.use(pinia2)
+    registerPiniaDevtools(app, pinia2)
+    await flushPromises()
+
+    expect(getDevtoolsRegistrations()).toHaveLength(2)
+
+    const store1 = useCounterStore(pinia)
+    const store2 = useCounterStore(pinia2)
+    await flushPromises()
+
+    // each registration resolves with its own API and receives only its own
+    // instance's store events
+    const apis = connectDevtoolsClientPerRegistration(createFakeDevtoolsApi)
+    await flushPromises()
+    expect(apis).toHaveLength(2)
+
+    store1.increment()
+    expect(apis[0].addTimelineEvent).toHaveBeenCalled()
+    expect(apis[1].addTimelineEvent).not.toHaveBeenCalled()
+
+    store2.increment()
+    expect(apis[1].addTimelineEvent).toHaveBeenCalled()
   })
 })

--- a/packages/pinia/__tests__/devtools-registration.spec.ts
+++ b/packages/pinia/__tests__/devtools-registration.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, defineStore } from '../src'
+import { devtoolsPlugin, registerPiniaDevtools } from '../src/devtools'
+import {
+  connectDevtoolsClient,
+  createFakeDevtoolsApi,
+  getDevtoolsRegistrations,
+  resetDevtoolsRegistrations,
+} from './devtools-api-stub'
+
+const useCounterStore = defineStore('counter', {
+  state: () => ({ n: 0 }),
+  actions: {
+    increment() {
+      this.n++
+    },
+  },
+})
+
+const useUserStore = defineStore('user', {
+  state: () => ({ name: 'Eduardo' }),
+  actions: {
+    rename(name: string) {
+      this.name = name
+    },
+  },
+})
+
+function setupApp() {
+  const pinia = createPinia()
+  pinia.use(devtoolsPlugin)
+  const wrapper = mount(
+    { template: '<div />' },
+    { global: { plugins: [pinia] } }
+  )
+  const app = (wrapper.vm as any).$.appContext.app
+  return { pinia, app }
+}
+
+describe('devtools registration', () => {
+  beforeEach(() => {
+    resetDevtoolsRegistrations()
+  })
+
+  it('registers the plugin once per application, with settings', () => {
+    const { app, pinia } = setupApp()
+
+    // pinia registers its devtools plugin at install time, before any store
+    registerPiniaDevtools(app, pinia)
+    expect(getDevtoolsRegistrations()).toHaveLength(1)
+
+    const { descriptor } = getDevtoolsRegistrations()[0]
+    expect(descriptor.id).toBe('dev.esm.pinia')
+    expect(descriptor.settings.logStoreChanges).toEqual({
+      label: 'Notify about new/deleted stores',
+      type: 'boolean',
+      defaultValue: true,
+    })
+
+    // registering again (e.g. HMR re-install) reuses the same registration
+    registerPiniaDevtools(app, pinia)
+    expect(getDevtoolsRegistrations()).toHaveLength(1)
+  })
+
+  it('does not register the plugin again when stores are created before the client connects', async () => {
+    const { app, pinia } = setupApp()
+
+    useCounterStore(pinia)
+    useUserStore(pinia)
+    await flushPromises()
+
+    // each store used to add its own setupDevtoolsPlugin registration
+    expect(getDevtoolsRegistrations()).toHaveLength(1)
+    expect(getDevtoolsRegistrations()[0].descriptor.app).toBe(app)
+  })
+
+  it('attaches store hooks through the shared API once the client connects', async () => {
+    const { pinia } = setupApp()
+
+    const store = useCounterStore(pinia)
+    await flushPromises()
+
+    const api = createFakeDevtoolsApi()
+    connectDevtoolsClient(api)
+    await flushPromises()
+
+    expect(api.addTimelineLayer).toHaveBeenCalled()
+    expect(api.addInspector).toHaveBeenCalled()
+
+    store.increment()
+    expect(api.addTimelineEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layerId: 'pinia:mutations',
+        event: expect.objectContaining({ title: '🛫 increment' }),
+      })
+    )
+    expect(api.sendInspectorState).toHaveBeenCalledWith('pinia')
+  })
+})

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -56,17 +56,19 @@ type DevtoolsPluginAPI = Parameters<
   Parameters<typeof setupDevtoolsPlugin>[1]
 >[0]
 
-// The devtools API of each application. `setupDevtoolsPlugin` queues its setup
-// callback until the devtools client connects, which may never happen, so the
-// promise is cached right away: every store awaits this exact registration
-// instead of adding a new one.
-const registeredApps = new WeakMap<App, Promise<DevtoolsPluginAPI>>()
+// The pending devtools API of each Pinia instance. `setupDevtoolsPlugin`
+// queues its setup callback until the devtools client connects, which may
+// never happen, so the promise is cached right away: every store awaits this
+// exact registration instead of adding a new one. The cache is keyed by the
+// Pinia instance because the setup callback closes over it: two Pinia
+// instances installed on the same application must not share an API.
+const registeredPinias = new WeakMap<Pinia, Promise<DevtoolsPluginAPI>>()
 
 /**
- * Register the Pinia devtools plugin, once per application, and resolve with
- * its API once the devtools client connects. Registering at install time,
- * with the settings, lets devtools read them without waiting for the first
- * store to be created (see #2818).
+ * Register the Pinia devtools plugin, once per Pinia instance, and resolve
+ * with its API once the devtools client connects. Registering at install
+ * time, with the settings, lets devtools read them without waiting for the
+ * first store to be created (see #2818).
  *
  * @param app - Vue application
  * @param pinia - pinia instance
@@ -75,14 +77,14 @@ export function registerPiniaDevtools(
   app: App,
   pinia: Pinia
 ): Promise<DevtoolsPluginAPI> {
-  const cached = registeredApps.get(app)
+  const cached = registeredPinias.get(pinia)
   if (cached) return cached
 
   let resolveApi!: (api: DevtoolsPluginAPI) => void
   const apiPromise = new Promise<DevtoolsPluginAPI>((resolve) => {
     resolveApi = resolve
   })
-  registeredApps.set(app, apiPromise)
+  registeredPinias.set(pinia, apiPromise)
 
   setupDevtoolsPlugin(
     {
@@ -624,7 +626,9 @@ export function devtoolsPlugin<
     app,
     // FIXME: is there a way to allow the assignment from Store<Id, S, G, A> to StoreGeneric?
     store as StoreGeneric
-  )
+  ).catch(() => {
+    // devtools failures must never break the application
+  })
 }
 
 declare global {

--- a/packages/pinia/src/devtools/plugin.ts
+++ b/packages/pinia/src/devtools/plugin.ts
@@ -52,14 +52,38 @@ interface TimelineEvent<TData = any, TMeta = any> {
  */
 const getStoreType = (id: string) => '🍍 ' + id
 
+type DevtoolsPluginAPI = Parameters<
+  Parameters<typeof setupDevtoolsPlugin>[1]
+>[0]
+
+// The devtools API of each application. `setupDevtoolsPlugin` queues its setup
+// callback until the devtools client connects, which may never happen, so the
+// promise is cached right away: every store awaits this exact registration
+// instead of adding a new one.
+const registeredApps = new WeakMap<App, Promise<DevtoolsPluginAPI>>()
+
 /**
- * Add the pinia plugin without any store. Allows displaying a Pinia plugin tab
- * as soon as it is added to the application.
+ * Register the Pinia devtools plugin, once per application, and resolve with
+ * its API once the devtools client connects. Registering at install time,
+ * with the settings, lets devtools read them without waiting for the first
+ * store to be created (see #2818).
  *
  * @param app - Vue application
  * @param pinia - pinia instance
  */
-export function registerPiniaDevtools(app: App, pinia: Pinia) {
+export function registerPiniaDevtools(
+  app: App,
+  pinia: Pinia
+): Promise<DevtoolsPluginAPI> {
+  const cached = registeredApps.get(app)
+  if (cached) return cached
+
+  let resolveApi!: (api: DevtoolsPluginAPI) => void
+  const apiPromise = new Promise<DevtoolsPluginAPI>((resolve) => {
+    resolveApi = resolve
+  })
+  registeredApps.set(app, apiPromise)
+
   setupDevtoolsPlugin(
     {
       id: 'dev.esm.pinia',
@@ -69,6 +93,18 @@ export function registerPiniaDevtools(app: App, pinia: Pinia) {
       homepage: 'https://pinia.vuejs.org',
       componentStateTypes,
       app,
+      settings: {
+        logStoreChanges: {
+          label: 'Notify about new/deleted stores',
+          type: 'boolean',
+          defaultValue: true,
+        },
+        // useEmojis: {
+        //   label: 'Use emojis in messages ⚡️',
+        //   type: 'boolean',
+        //   defaultValue: true,
+        // },
+      },
     },
     (api) => {
       if (typeof api.now !== 'function') {
@@ -306,209 +342,192 @@ export function registerPiniaDevtools(app: App, pinia: Pinia) {
           isTimelineActive = true
         }
       })
+
+      resolveApi(api)
     }
   )
+
+  return apiPromise
 }
 
-function addStoreToDevtools(app: App, store: StoreGeneric) {
+async function addStoreToDevtools(app: App, store: StoreGeneric) {
   if (!componentStateTypes.includes(getStoreType(store.$id))) {
     componentStateTypes.push(getStoreType(store.$id))
   }
 
-  setupDevtoolsPlugin(
-    {
-      id: 'dev.esm.pinia',
-      label: 'Pinia 🍍',
-      logo: 'https://pinia.vuejs.org/logo.svg',
-      packageName: 'pinia',
-      homepage: 'https://pinia.vuejs.org',
-      componentStateTypes,
-      app,
-      settings: {
-        logStoreChanges: {
-          label: 'Notify about new/deleted stores',
-          type: 'boolean',
-          defaultValue: true,
+  // Reuse the plugin registered at install time. Each store only adds its own
+  // timeline and inspector hooks, once the shared API is available.
+  const api = await registerPiniaDevtools(app, store._p)
+
+  // gracefully handle errors
+  const now = typeof api.now === 'function' ? api.now.bind(api) : Date.now
+
+  store.$onAction(({ after, onError, name, args }) => {
+    const groupId = runningActionId++
+
+    api.addTimelineEvent({
+      layerId: MUTATIONS_LAYER_ID,
+      event: {
+        time: now(),
+        title: '🛫 ' + name,
+        subtitle: 'start',
+        data: {
+          store: formatDisplay(store.$id),
+          action: formatDisplay(name),
+          args,
         },
-        // useEmojis: {
-        //   label: 'Use emojis in messages ⚡️',
-        //   type: 'boolean',
-        //   defaultValue: true,
-        // },
+        groupId,
       },
-    },
-    (api) => {
-      // gracefully handle errors
-      const now = typeof api.now === 'function' ? api.now.bind(api) : Date.now
+    })
 
-      store.$onAction(({ after, onError, name, args }) => {
-        const groupId = runningActionId++
-
-        api.addTimelineEvent({
-          layerId: MUTATIONS_LAYER_ID,
-          event: {
-            time: now(),
-            title: '🛫 ' + name,
-            subtitle: 'start',
-            data: {
-              store: formatDisplay(store.$id),
-              action: formatDisplay(name),
-              args,
-            },
-            groupId,
+    after((result) => {
+      activeAction = undefined
+      api.addTimelineEvent({
+        layerId: MUTATIONS_LAYER_ID,
+        event: {
+          time: now(),
+          title: '🛬 ' + name,
+          subtitle: 'end',
+          data: {
+            store: formatDisplay(store.$id),
+            action: formatDisplay(name),
+            args,
+            result,
           },
-        })
-
-        after((result) => {
-          activeAction = undefined
-          api.addTimelineEvent({
-            layerId: MUTATIONS_LAYER_ID,
-            event: {
-              time: now(),
-              title: '🛬 ' + name,
-              subtitle: 'end',
-              data: {
-                store: formatDisplay(store.$id),
-                action: formatDisplay(name),
-                args,
-                result,
-              },
-              groupId,
-            },
-          })
-        })
-
-        onError((error) => {
-          activeAction = undefined
-          api.addTimelineEvent({
-            layerId: MUTATIONS_LAYER_ID,
-            event: {
-              time: now(),
-              logType: 'error',
-              title: '💥 ' + name,
-              subtitle: 'end',
-              data: {
-                store: formatDisplay(store.$id),
-                action: formatDisplay(name),
-                args,
-                error,
-              },
-              groupId,
-            },
-          })
-        })
-      }, true)
-
-      store._customProperties.forEach((name) => {
-        watch(
-          () => unref<unknown>(store[name]),
-          (newValue, oldValue) => {
-            api.notifyComponentUpdate()
-            api.sendInspectorState(INSPECTOR_ID)
-            if (isTimelineActive) {
-              api.addTimelineEvent({
-                layerId: MUTATIONS_LAYER_ID,
-                event: {
-                  time: now(),
-                  title: 'Change',
-                  subtitle: name,
-                  data: {
-                    newValue,
-                    oldValue,
-                  },
-                  groupId: activeAction,
-                },
-              })
-            }
-          },
-          { deep: true }
-        )
-      })
-
-      store.$subscribe(
-        ({ events, type }, state) => {
-          api.notifyComponentUpdate()
-          api.sendInspectorState(INSPECTOR_ID)
-
-          if (!isTimelineActive) return
-          // rootStore.state[store.id] = state
-
-          const eventData: TimelineEvent = {
-            time: now(),
-            title: formatMutationType(type),
-            data: assign(
-              { store: formatDisplay(store.$id) },
-              formatEventData(events)
-            ),
-            groupId: activeAction,
-          }
-
-          if (type === MutationType.patchFunction) {
-            eventData.subtitle = '⤵️'
-          } else if (type === MutationType.patchObject) {
-            eventData.subtitle = '🧩'
-          } else if (events && !Array.isArray(events)) {
-            eventData.subtitle = events.type
-          }
-
-          if (events) {
-            eventData.data['rawEvent(s)'] = {
-              _custom: {
-                display: 'DebuggerEvent',
-                type: 'object',
-                tooltip: 'raw DebuggerEvent[]',
-                value: events,
-              },
-            }
-          }
-
-          api.addTimelineEvent({
-            layerId: MUTATIONS_LAYER_ID,
-            event: eventData,
-          })
+          groupId,
         },
-        { detached: true, flush: 'sync' }
-      )
-
-      const hotUpdate = store._hotUpdate
-      store._hotUpdate = markRaw((newStore) => {
-        hotUpdate(newStore)
-        api.addTimelineEvent({
-          layerId: MUTATIONS_LAYER_ID,
-          event: {
-            time: now(),
-            title: '🔥 ' + store.$id,
-            subtitle: 'HMR update',
-            data: {
-              store: formatDisplay(store.$id),
-              info: formatDisplay(`HMR update`),
-            },
-          },
-        })
-        // update the devtools too
-        api.notifyComponentUpdate()
-        api.sendInspectorTree(INSPECTOR_ID)
-        api.sendInspectorState(INSPECTOR_ID)
       })
+    })
 
-      const { $dispose } = store
-      store.$dispose = () => {
-        $dispose()
+    onError((error) => {
+      activeAction = undefined
+      api.addTimelineEvent({
+        layerId: MUTATIONS_LAYER_ID,
+        event: {
+          time: now(),
+          logType: 'error',
+          title: '💥 ' + name,
+          subtitle: 'end',
+          data: {
+            store: formatDisplay(store.$id),
+            action: formatDisplay(name),
+            args,
+            error,
+          },
+          groupId,
+        },
+      })
+    })
+  }, true)
+
+  store._customProperties.forEach((name) => {
+    watch(
+      () => unref<unknown>(store[name]),
+      (newValue, oldValue) => {
         api.notifyComponentUpdate()
-        api.sendInspectorTree(INSPECTOR_ID)
         api.sendInspectorState(INSPECTOR_ID)
-        api.getSettings().logStoreChanges &&
-          toastMessage(`Disposed "${store.$id}" store 🗑`)
+        if (isTimelineActive) {
+          api.addTimelineEvent({
+            layerId: MUTATIONS_LAYER_ID,
+            event: {
+              time: now(),
+              title: 'Change',
+              subtitle: name,
+              data: {
+                newValue,
+                oldValue,
+              },
+              groupId: activeAction,
+            },
+          })
+        }
+      },
+      { deep: true }
+    )
+  })
+
+  store.$subscribe(
+    ({ events, type }, state) => {
+      api.notifyComponentUpdate()
+      api.sendInspectorState(INSPECTOR_ID)
+
+      if (!isTimelineActive) return
+      // rootStore.state[store.id] = state
+
+      const eventData: TimelineEvent = {
+        time: now(),
+        title: formatMutationType(type),
+        data: assign(
+          { store: formatDisplay(store.$id) },
+          formatEventData(events)
+        ),
+        groupId: activeAction,
       }
 
-      // trigger an update so it can display new registered stores
-      api.notifyComponentUpdate()
-      api.sendInspectorTree(INSPECTOR_ID)
-      api.sendInspectorState(INSPECTOR_ID)
-      api.getSettings().logStoreChanges &&
-        toastMessage(`"${store.$id}" store installed 🆕`)
-    }
+      if (type === MutationType.patchFunction) {
+        eventData.subtitle = '⤵️'
+      } else if (type === MutationType.patchObject) {
+        eventData.subtitle = '🧩'
+      } else if (events && !Array.isArray(events)) {
+        eventData.subtitle = events.type
+      }
+
+      if (events) {
+        eventData.data['rawEvent(s)'] = {
+          _custom: {
+            display: 'DebuggerEvent',
+            type: 'object',
+            tooltip: 'raw DebuggerEvent[]',
+            value: events,
+          },
+        }
+      }
+
+      api.addTimelineEvent({
+        layerId: MUTATIONS_LAYER_ID,
+        event: eventData,
+      })
+    },
+    { detached: true, flush: 'sync' }
   )
+
+  const hotUpdate = store._hotUpdate
+  store._hotUpdate = markRaw((newStore) => {
+    hotUpdate(newStore)
+    api.addTimelineEvent({
+      layerId: MUTATIONS_LAYER_ID,
+      event: {
+        time: now(),
+        title: '🔥 ' + store.$id,
+        subtitle: 'HMR update',
+        data: {
+          store: formatDisplay(store.$id),
+          info: formatDisplay(`HMR update`),
+        },
+      },
+    })
+    // update the devtools too
+    api.notifyComponentUpdate()
+    api.sendInspectorTree(INSPECTOR_ID)
+    api.sendInspectorState(INSPECTOR_ID)
+  })
+
+  const { $dispose } = store
+  store.$dispose = () => {
+    $dispose()
+    api.notifyComponentUpdate()
+    api.sendInspectorTree(INSPECTOR_ID)
+    api.sendInspectorState(INSPECTOR_ID)
+    api.getSettings().logStoreChanges &&
+      toastMessage(`Disposed "${store.$id}" store 🗑`)
+  }
+
+  // trigger an update so it can display new registered stores
+  api.notifyComponentUpdate()
+  api.sendInspectorTree(INSPECTOR_ID)
+  api.sendInspectorState(INSPECTOR_ID)
+  api.getSettings().logStoreChanges &&
+    toastMessage(`"${store.$id}" store installed 🆕`)
 }
 
 let runningActionId = 0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,18 @@ export default defineConfig({
           new URL('./packages/pinia/src', import.meta.url)
         ),
       },
+      {
+        // controllable stub for the devtools integration, see
+        // packages/pinia/__tests__/devtools-api-stub.ts. No test exercises
+        // the real module (`__USE_DEVTOOLS__` is `false` in tests).
+        find: /^@vue\/devtools-api$/,
+        replacement: fileURLToPath(
+          new URL(
+            './packages/pinia/__tests__/devtools-api-stub.ts',
+            import.meta.url
+          )
+        ),
+      },
     ],
   },
 


### PR DESCRIPTION
Fixes #2818, supersedes #2858.

### Problem

Pinia calls `setupDevtoolsPlugin` twice with the same plugin id: once at install time without settings (`registerPiniaDevtools`), and once with settings when the first store is created (`addStoreToDevtools`). Vue Devtools read the plugin settings at mount, so the settings panel stayed empty until the first store was created. The inspector and timeline hooks were also registered twice.

### Solution

`registerPiniaDevtools` now declares the settings and registers the plugin exactly once per application, caching the API **promise** in a `WeakMap`. Each store created later awaits the same registration through `addStoreToDevtools` and only attaches its own timeline/inspector hooks.

This follows the direction of the `fix/devtools-setup-once` branch (and @posva's comment on #2858). One difference: caching the promise instead of the resolved API. Caching only the resolved API would make every store created before the devtools client connects call `setupDevtoolsPlugin` again (one registration per store), which is the likely source of the "timeline doesn't show up" issue encountered on that branch.

### Tests

The devtools module previously had no tests. Tests now drive the registration lifecycle through a small `@vue/devtools-api` stub aliased in `vitest.config.ts` (test-only config; `__USE_DEVTOOLS__` is `false` in tests, so no other test executes devtools code):

- the plugin is registered exactly once per application, with settings, at install time
- creating stores before the client connects does not register the plugin again
- once the client connects, store actions and mutations flow through the shared API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Pinia DevTools registration so each Pinia instance receives its own isolated connection.
  - Improved support for DevTools connecting after stores are created.
  - Store mutations now reliably appear in the DevTools timeline and update inspector state.
  - DevTools errors no longer interrupt application behavior.
- **Testing**
  - Added coverage for registration, client connections, multiple Pinia instances, store mutations, timeline events, and inspector updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->